### PR TITLE
testnet: Add network listener to keep track of counterparties

### DIFF
--- a/testnet.renegade.fi/components/orders-panel.tsx
+++ b/testnet.renegade.fi/components/orders-panel.tsx
@@ -1,14 +1,9 @@
 "use client"
 
-import React from "react"
+import React, { useEffect } from "react"
 import { useRenegade } from "@/contexts/Renegade/renegade-context"
 import { TaskType } from "@/contexts/Renegade/types"
-import {
-  EditIcon,
-  LockIcon,
-  SmallCloseIcon,
-  UnlockIcon,
-} from "@chakra-ui/icons"
+import { LockIcon, SmallCloseIcon, UnlockIcon } from "@chakra-ui/icons"
 import { Box, Flex, Image, Text } from "@chakra-ui/react"
 import { Order } from "@renegade-fi/renegade-js"
 import { useModal as useModalConnectKit } from "connectkit"
@@ -26,9 +21,10 @@ interface SingleOrderProps {
 }
 function SingleOrder(props: SingleOrderProps) {
   const { accountId, setTask } = useRenegade()
-  const [baseLogoUrl, setBaseLogoUrl] = React.useState("DEFAULT.png")
-  const [quoteLogoUrl, setQuoteLogoUrl] = React.useState("DEFAULT.png")
-  React.useEffect(() => {
+  const [baseLogoUrl, setBaseLogoUrl] = React.useState("")
+  const [quoteLogoUrl, setQuoteLogoUrl] = React.useState("")
+
+  useEffect(() => {
     TICKER_TO_LOGO_URL_HANDLE.then((tickerToLogoUrl) => {
       setBaseLogoUrl(
         tickerToLogoUrl[ADDR_TO_TICKER["0x" + props.order.baseToken.address]]
@@ -38,12 +34,23 @@ function SingleOrder(props: SingleOrderProps) {
       )
     })
   })
+
+  const handleCancel = () => {
+    if (!accountId) return
+    renegade.task
+      .cancelOrder(accountId, props.order.orderId)
+      .then(async ([taskId, taskJob]) => {
+        setTask(taskId, TaskType.CancelOrder)
+        return taskJob
+      })
+      .then(() => setTask(undefined, undefined))
+  }
+
   return (
     <Flex
       alignItems="center"
-      gap="5px"
-      width="100%"
-      padding="0 6% 0 6%"
+      justifyContent="space-evenly"
+      gap="4px"
       color="white.60"
       borderColor="white.20"
       borderBottom="var(--border)"
@@ -54,30 +61,22 @@ function SingleOrder(props: SingleOrderProps) {
       cursor="pointer"
       transition="filter 0.1s"
       filter="grayscale(1)"
+      paddingY="10px"
     >
-      <Text marginRight="5px" fontFamily="Favorit">
-        Open
-      </Text>
-      <Box position="relative" width="30px" height="40px">
+      <Text fontFamily="Favorit">Open</Text>
+      <Box position="relative" width="45px" height="40px">
         <Image width="25px" height="25px" alt="Quote logo" src={quoteLogoUrl} />
         <Image
           position="absolute"
-          right="0"
-          bottom="0"
+          right="1"
+          bottom="1"
           width="25px"
           height="25px"
           alt="Base logo"
           src={baseLogoUrl}
         />
       </Box>
-      <Flex
-        alignItems="flex-start"
-        flexDirection="column"
-        flexGrow="1"
-        marginLeft="5px"
-        padding="10px 0 10px 0"
-        fontFamily="Favorit"
-      >
+      <Flex alignItems="flex-start" flexDirection="column" fontFamily="Favorit">
         <Text fontSize="1.1em" lineHeight="1">
           {props.order.amount.toString()}{" "}
           {ADDR_TO_TICKER["0x" + props.order.baseToken.address]}
@@ -86,7 +85,7 @@ function SingleOrder(props: SingleOrderProps) {
           {props.order.side.toUpperCase()}
         </Text>
       </Flex>
-      <EditIcon
+      {/* <EditIcon
         width="calc(0.5 * var(--banner-height))"
         height="calc(0.5 * var(--banner-height))"
         padding="2px"
@@ -95,14 +94,7 @@ function SingleOrder(props: SingleOrderProps) {
         _hover={{
           background: "white.10",
         }}
-        onClick={() => {
-          if (accountId) {
-            renegade.task
-              .cancelOrder(accountId, props.order.orderId)
-              .then(([taskId]) => setTask(taskId, TaskType.CancelOrder))
-          }
-        }}
-      />
+      /> */}
       <SmallCloseIcon
         width="calc(0.5 * var(--banner-height))"
         height="calc(0.5 * var(--banner-height))"
@@ -111,13 +103,7 @@ function SingleOrder(props: SingleOrderProps) {
         _hover={{
           background: "white.10",
         }}
-        onClick={() => {
-          if (accountId) {
-            renegade.task
-              .cancelOrder(accountId, props.order.orderId)
-              .then(([taskId]) => setTask(taskId, TaskType.CancelOrder))
-          }
-        }}
+        onClick={handleCancel}
       />
     </Flex>
   )

--- a/testnet.renegade.fi/components/orders-panel.tsx
+++ b/testnet.renegade.fi/components/orders-panel.tsx
@@ -205,47 +205,6 @@ function OrdersPanel(props: OrdersPanelProps) {
 
 function CounterpartiesPanel() {
   const { counterparties } = useRenegade()
-  let panelBody: React.ReactElement
-
-  if (Object.keys(counterparties).length === 0) {
-    panelBody = (
-      <Text
-        padding="0 10% 0 10%"
-        color="white.50"
-        fontSize="0.8em"
-        fontWeight="100"
-        textAlign="center"
-      >
-        No counterparties have been discovered.
-      </Text>
-    )
-  } else {
-    panelBody = (
-      <>
-        {Object.values(counterparties).map((counterparty) => {
-          const port = counterparty.multiaddr.split("/")[4]
-          const ipAddr = counterparty.multiaddr.split("/")[6]
-          return (
-            <Flex
-              key={counterparty.peerId}
-              flexDirection="column"
-              gap="2px"
-              width="100%"
-              padding="4% 8% 4% 8%"
-              borderColor="white.20"
-            >
-              <Text color="white.80" fontSize="0.8em">
-                Peer ID: {counterparty.peerId.slice(-16)}
-              </Text>
-              <Text color="white.60" fontSize="0.2em">
-                {ipAddr}:{port}
-              </Text>
-            </Flex>
-          )
-        })}
-      </>
-    )
-  }
   return (
     <Flex
       position="relative"
@@ -258,7 +217,7 @@ function CounterpartiesPanel() {
       borderBottom="var(--border)"
     >
       <Text>Counterparties:&nbsp;</Text>
-      <Text>42</Text>
+      <Text>{Object.keys(counterparties).length}</Text>
     </Flex>
   )
 }

--- a/testnet.renegade.fi/components/place-order-button.tsx
+++ b/testnet.renegade.fi/components/place-order-button.tsx
@@ -84,14 +84,14 @@ export default function PlaceOrderButton() {
           if (!baseTokenAmount) {
             return
           }
-          // if (!address) {
-          //   setOpen(true)
-          //   return
-          // }
-          // if (!isSignedIn) {
-          //   onOpenSignIn()
-          //   return
-          // }
+          if (!address) {
+            setOpen(true)
+            return
+          }
+          if (!isSignedIn) {
+            onOpenSignIn()
+            return
+          }
           onOpenPlaceOrder()
         }}
       >

--- a/testnet.renegade.fi/components/steppers/order-stepper/order-stepper.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/order-stepper.tsx
@@ -20,13 +20,8 @@ const OrderStepperInner = () => {
         background="rgba(0, 0, 0, 0.25)"
         backdropFilter="blur(8px)"
       />
-      <ModalContent
-        // paddingTop="6"
-        // paddingBottom="4"
-        background="surfaces.1"
-        borderRadius="10px"
-      >
-        <Flex justifyContent="center" flexDirection="column" height="324px">
+      <ModalContent background="surfaces.1" borderRadius="10px">
+        <Flex justifyContent="center" flexDirection="column" height="348px">
           <Fade
             transition={{ enter: { duration: 1 } }}
             in={step === Step.DEFAULT}

--- a/testnet.renegade.fi/components/steppers/order-stepper/steps/confirm-step.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/steps/confirm-step.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react"
 import { useOrder } from "@/contexts/Order/order-context"
 import { ArrowForwardIcon } from "@chakra-ui/icons"
 import {
@@ -11,11 +12,22 @@ import {
   Text,
 } from "@chakra-ui/react"
 
-import { Step, useStepper } from "../order-stepper"
+import { useStepper } from "../order-stepper"
 
-export default function DefaultStep() {
-  const { setStep } = useStepper()
-  const { baseTicker, baseTokenAmount } = useOrder()
+export default function ConfirmStep() {
+  const { onNext } = useStepper()
+  const {
+    onPlaceOrder,
+    baseTicker,
+    baseTokenAmount,
+    midpointPrice,
+    direction,
+  } = useOrder()
+  const handleClick = useCallback(() => {
+    onPlaceOrder()
+    onNext()
+  }, [onNext, onPlaceOrder])
+
   return (
     <>
       <ModalCloseButton />
@@ -32,7 +44,7 @@ export default function DefaultStep() {
             fontSize="1.3em"
             fontWeight="200"
           >
-            You&apos;re buying
+            You&apos;re {direction === "buy" ? "buying" : "selling"}
           </Text>
           <Text fontFamily="Aime" fontSize="3em" fontWeight="700">
             {`${baseTokenAmount} ${baseTicker}`}
@@ -56,8 +68,10 @@ export default function DefaultStep() {
               width="100%"
               fontFamily="Favorit"
             >
-              <Text color="white.50">Pay at most</Text>
-              <Text>???? USDC</Text>
+              <Text color="white.50">
+                {direction === "buy" ? "Pay at most" : "Receive at least"}
+              </Text>
+              <Text>{midpointPrice}&nbsp;USDC</Text>
             </Flex>
           </Flex>
         </Flex>
@@ -80,12 +94,12 @@ export default function DefaultStep() {
           }}
           transition="0.15s"
           backgroundColor="transparent"
-          onClick={() => {
-            setStep(Step.LOADING)
-          }}
+          onClick={handleClick}
         >
           <HStack spacing="4px">
-            <Text>Buy {baseTicker}</Text>
+            <Text>{`${
+              direction === "buy" ? "Buy" : "Sell"
+            } ${baseTicker}`}</Text>
             <ArrowForwardIcon />
           </HStack>
         </Button>

--- a/testnet.renegade.fi/components/steppers/order-stepper/steps/exit-step.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/steps/exit-step.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useState } from "react"
 import { useOrder } from "@/contexts/Order/order-context"
-import { ArrowForwardIcon } from "@chakra-ui/icons"
 import {
   Button,
   Divider,
   Flex,
-  HStack,
   ModalBody,
   ModalCloseButton,
   ModalFooter,
@@ -14,8 +12,8 @@ import {
 
 import { useStepper } from "../order-stepper"
 
-export default function DefaultStep() {
-  const { baseTicker, baseTokenAmount } = useOrder()
+export default function ExitStep() {
+  const { baseTicker, baseTokenAmount, direction } = useOrder()
   const { onClose } = useStepper()
   const [isHovered, setIsHovered] = useState(true)
   useEffect(() => {
@@ -43,7 +41,7 @@ export default function DefaultStep() {
             fontSize="1.3em"
             fontWeight="200"
           >
-            You bought
+            Order to {direction === "buy" ? "buy" : "sell"}
           </Text>
           <Text
             fontFamily="Aime"
@@ -54,6 +52,14 @@ export default function DefaultStep() {
             {`${baseTokenAmount} ${baseTicker}`}
           </Text>
           <Flex flexDirection="column" gap="12px" width="100%">
+            <Text
+              color="white.50"
+              fontFamily="Favorit Extended"
+              fontSize="1.3em"
+              fontWeight="200"
+            >
+              has been placed
+            </Text>
             <Divider />
             <Flex
               alignItems="center"
@@ -74,7 +80,9 @@ export default function DefaultStep() {
               width="100%"
               fontFamily="Favorit"
             >
-              <Text color="white.50">Pay at most</Text>
+              <Text color="white.50">
+                {direction === "buy" ? "Paid at most" : "Received at least"}
+              </Text>
               <Text variant={isHovered ? undefined : "blurred"}>???? USDC</Text>
             </Flex>
           </Flex>
@@ -102,10 +110,7 @@ export default function DefaultStep() {
             onClose()
           }}
         >
-          <HStack spacing="4px">
-            <Text>Close</Text>
-            <ArrowForwardIcon />
-          </HStack>
+          Close
         </Button>
       </ModalFooter>
     </>

--- a/testnet.renegade.fi/components/steppers/order-stepper/steps/loading-step.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/steps/loading-step.tsx
@@ -1,15 +1,17 @@
 import { useEffect } from "react"
+import { useRenegade } from "@/contexts/Renegade/renegade-context"
+import { TaskState, TaskType } from "@/contexts/Renegade/types"
 import { Flex, ModalBody, ModalFooter, Spinner, Text } from "@chakra-ui/react"
 
-import { Step, useStepper } from "../order-stepper"
+import { useStepper } from "../order-stepper"
 
 export default function LoadingStep() {
-  const { setStep } = useStepper()
+  const { onNext } = useStepper()
+  const { taskState, taskType } = useRenegade()
   useEffect(() => {
-    setTimeout(() => {
-      setStep(Step.EXIT)
-    }, 2000)
-  }, [setStep])
+    if (taskType === TaskType.PlaceOrder && taskState === TaskState.Completed)
+      onNext()
+  }, [onNext, taskState, taskType])
 
   return (
     <>

--- a/testnet.renegade.fi/contexts/Order/order-context.tsx
+++ b/testnet.renegade.fi/contexts/Order/order-context.tsx
@@ -1,8 +1,19 @@
 "use client"
 
-import { createContext, useContext, useEffect, useState } from "react"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react"
 import { useParams, useRouter } from "next/navigation"
+import { Order, OrderId, Token } from "@renegade-fi/renegade-js"
 
+import { renegade } from "../../app/providers"
+import { HealthStates } from "../../types"
+import { useRenegade } from "../Renegade/renegade-context"
+import { CounterpartyOrder, TaskType } from "../Renegade/types"
 import { Direction, OrderContextValue } from "./types"
 
 type OrderProviderProps = { children: React.ReactNode }
@@ -24,7 +35,12 @@ function OrderProvider({ children }: OrderProviderProps) {
     router.push(`/${baseTicker}/${token}`)
   }
   const [baseTokenAmount, setBaseTokenAmount] = useState(0)
-  // TODO: sync order details with local storage
+  const { accountId, setTask } = useRenegade()
+  const [midpointPrice, setMidpointPrice] = useState<number>()
+
+  const [orderBook, setOrderBook] = useState<
+    Record<OrderId, CounterpartyOrder>
+  >({})
 
   useEffect(() => {
     if (!baseTicker || !quoteTicker) return
@@ -35,6 +51,80 @@ function OrderProvider({ children }: OrderProviderProps) {
       )
     }
   }, [baseTicker, quoteTicker, router])
+
+  const fetchPrice = useCallback(async () => {
+    if (!baseTicker || !quoteTicker) return
+    const { median }: HealthStates = await renegade.queryExchangeHealthStates(
+      new Token({ ticker: baseTicker }),
+      new Token({ ticker: quoteTicker })
+    )
+    const price =
+      median.Nominal?.midpointPrice ||
+      median.DataTooStale?.[0].midpointPrice ||
+      0
+    return price
+  }, [baseTicker, quoteTicker])
+
+  const handleOrderListener = useCallback(async () => {
+    await renegade.registerOrderBookCallback((message: string) => {
+      console.log("[Order Book]", message)
+      const orderBookEvent = JSON.parse(message)
+      const orderBookEventType = orderBookEvent.type
+      const orderBookEventOrder = orderBookEvent.order
+      if (
+        orderBookEventType === "NewOrder" ||
+        orderBookEventType === "OrderStateChange"
+      ) {
+        setOrderBook((orderBook) => {
+          const newOrderBook = { ...orderBook }
+          newOrderBook[orderBookEventOrder.id] = {
+            orderId: orderBookEventOrder.id,
+            publicShareNullifier: orderBookEventOrder.public_share_nullifier,
+            isLocal: orderBookEventOrder.local,
+            clusterId: orderBookEventOrder.cluster,
+            state: orderBookEventOrder.state,
+            timestamp: orderBookEventOrder.timestamp,
+            handshakeState: "not-matching",
+          } as CounterpartyOrder
+          return newOrderBook
+        })
+      } else {
+        console.error("Unknown order book event type:", orderBookEventType)
+      }
+    })
+  }, [])
+
+  const handlePlaceOrder = useCallback(async () => {
+    if (
+      !accountId ||
+      !baseTicker ||
+      !quoteTicker ||
+      !baseTokenAmount ||
+      !direction
+    )
+      return
+    const order = new Order({
+      baseToken: new Token({ ticker: baseTicker }),
+      quoteToken: new Token({ ticker: quoteTicker }),
+      side: direction,
+      type: "limit",
+      amount: BigInt(baseTokenAmount),
+      price: await fetchPrice(),
+    })
+    const [taskId, taskJob] = await renegade.task.placeOrder(accountId, order)
+    setTask(taskId, TaskType.PlaceOrder)
+    await taskJob.then(() => setTask(undefined, undefined))
+    handleOrderListener()
+  }, [
+    accountId,
+    baseTicker,
+    baseTokenAmount,
+    direction,
+    fetchPrice,
+    handleOrderListener,
+    quoteTicker,
+    setTask,
+  ])
 
   return (
     <OrderStateContext.Provider
@@ -47,6 +137,9 @@ function OrderProvider({ children }: OrderProviderProps) {
         setQuoteToken: handleSetQuoteToken,
         baseTokenAmount,
         setBaseTokenAmount,
+        setMidpointPrice,
+        onPlaceOrder: handlePlaceOrder,
+        midpointPrice,
       }}
     >
       {children}

--- a/testnet.renegade.fi/contexts/Order/types.ts
+++ b/testnet.renegade.fi/contexts/Order/types.ts
@@ -12,4 +12,7 @@ export interface OrderContextValue {
   setQuoteToken: (token: string) => void
   baseTokenAmount: number
   setBaseTokenAmount: (amount: number) => void
+  setMidpointPrice: (price?: number) => void
+  onPlaceOrder: () => void
+  midpointPrice?: number
 }

--- a/testnet.renegade.fi/contexts/Renegade/renegade-context.tsx
+++ b/testnet.renegade.fi/contexts/Renegade/renegade-context.tsx
@@ -74,7 +74,7 @@ function RenegadeProvider({ children }: RenegadeProviderProps) {
     const accountId = renegade.registerAccount(keychain)
     const [taskId, taskJob] = await renegade.task.initializeAccount(accountId)
     setTask(taskId, TaskType.InitializeAccount)
-    await taskJob.then(() => setTask(undefined))
+    await taskJob.then(() => setTask(undefined, undefined))
     setAccountId(accountId)
     refreshAccount(accountId)
     await renegade.registerAccountCallback(
@@ -87,6 +87,7 @@ function RenegadeProvider({ children }: RenegadeProviderProps) {
   const refreshAccount = (accountId?: AccountId) => {
     if (!accountId) return
     setBalances(renegade.getBalances(accountId))
+    setOrders(renegade.getOrders(accountId))
   }
 
   React.useEffect(() => {
@@ -122,23 +123,9 @@ function RenegadeProvider({ children }: RenegadeProviderProps) {
     setTaskId(newTaskId)
     setTaskType(taskType)
     setTaskState(TaskState.Proving)
-    // toast({
-    //   title: "New Task State",
-    //   description: "Proving",
-    //   status: "info",
-    //   duration: 5000,
-    //   isClosable: true,
-    // });
     await renegade.registerTaskCallback((message: string) => {
       const taskUpdate = JSON.parse(message).state
       setTaskState(taskUpdate.state as TaskState)
-      // toast({
-      //   title: "New Task State",
-      //   description: taskUpdate.state,
-      //   status: "info",
-      //   duration: 5000,
-      //   isClosable: true,
-      // });
     }, newTaskId)
   }
 

--- a/testnet.renegade.fi/contexts/Renegade/types.ts
+++ b/testnet.renegade.fi/contexts/Renegade/types.ts
@@ -50,7 +50,7 @@ export interface RenegadeContextType {
   counterparties: Record<PeerId, Counterparty>
   orderBook: Record<OrderId, CounterpartyOrder>
   setAccount: (oldAccountId?: AccountId, keychain?: Keychain) => Promise<void>
-  setTask: (newTaskId: TaskId, taskType: TaskType) => Promise<void>
+  setTask: (newTaskId?: TaskId, taskType?: TaskType) => Promise<void>
 }
 
 export enum TaskState {


### PR DESCRIPTION
This PR adds functionality to listen to network events emitted by the relayer. We use this to update the number of connected couterparties in the order panel, in addition to streaming events regarding the order book and MPC.