### PR TITLE
testnet: Add network listener to keep track of counterparties

### DIFF
--- a/testnet.renegade.fi/components/orders-panel.tsx
+++ b/testnet.renegade.fi/components/orders-panel.tsx
@@ -205,47 +205,6 @@ function OrdersPanel(props: OrdersPanelProps) {
 
 function CounterpartiesPanel() {
   const { counterparties } = useRenegade()
-  let panelBody: React.ReactElement
-
-  if (Object.keys(counterparties).length === 0) {
-    panelBody = (
-      <Text
-        padding="0 10% 0 10%"
-        color="white.50"
-        fontSize="0.8em"
-        fontWeight="100"
-        textAlign="center"
-      >
-        No counterparties have been discovered.
-      </Text>
-    )
-  } else {
-    panelBody = (
-      <>
-        {Object.values(counterparties).map((counterparty) => {
-          const port = counterparty.multiaddr.split("/")[4]
-          const ipAddr = counterparty.multiaddr.split("/")[6]
-          return (
-            <Flex
-              key={counterparty.peerId}
-              flexDirection="column"
-              gap="2px"
-              width="100%"
-              padding="4% 8% 4% 8%"
-              borderColor="white.20"
-            >
-              <Text color="white.80" fontSize="0.8em">
-                Peer ID: {counterparty.peerId.slice(-16)}
-              </Text>
-              <Text color="white.60" fontSize="0.2em">
-                {ipAddr}:{port}
-              </Text>
-            </Flex>
-          )
-        })}
-      </>
-    )
-  }
   return (
     <Flex
       position="relative"
@@ -258,7 +217,7 @@ function CounterpartiesPanel() {
       borderBottom="var(--border)"
     >
       <Text>Counterparties:&nbsp;</Text>
-      <Text>42</Text>
+      <Text>{Object.keys(counterparties).length}</Text>
     </Flex>
   )
 }

--- a/testnet.renegade.fi/contexts/Renegade/renegade-context.tsx
+++ b/testnet.renegade.fi/contexts/Renegade/renegade-context.tsx
@@ -55,6 +55,49 @@ function RenegadeProvider({ children }: RenegadeProviderProps) {
     Record<OrderId, CounterpartyOrder>
   >({})
 
+  // TODO: Does not include existing peers
+  // Stream network, order book, and MPC events.
+  const networkCallbackId = React.useRef<CallbackId>()
+  React.useEffect(() => {
+    if (networkCallbackId.current) return
+    const handleNetworkListener = async () => {
+      console.log("adding listener")
+      await renegade
+        .registerNetworkCallback((message: string) => {
+          console.log("[Network]", message)
+          const networkEvent = JSON.parse(message)
+          const networkEventType = networkEvent.type
+          const networkEventPeer = networkEvent.peer
+          if (networkEventType === "NewPeer") {
+            setCounterparties((counterparties) => {
+              const newCounterparties = { ...counterparties }
+              newCounterparties[networkEventPeer.id] = {
+                peerId: networkEventPeer.id,
+                clusterId: networkEventPeer.cluster_id,
+                multiaddr: networkEventPeer.addr,
+              } as Counterparty
+              return newCounterparties
+            })
+          } else if (networkEventType === "PeerExpired") {
+            setCounterparties((counterparties) => {
+              const newCounterparties = { ...counterparties }
+              delete newCounterparties[networkEventPeer.id]
+              return newCounterparties
+            })
+          } else {
+            console.error("Unknown network event type:", networkEventType)
+          }
+        })
+        .then((callbackId) => (networkCallbackId.current = callbackId))
+    }
+    handleNetworkListener()
+    return () => {
+      if (networkCallbackId.current) {
+        renegade.releaseCallback(networkCallbackId.current)
+      }
+    }
+  }, [])
+
   // Define the setAccount handler. This handler unregisters the previous
   // account ID, registers the new account ID, and starts an initializeAccount
   // task.


### PR DESCRIPTION
This PR adds a network listener to listen to the number of counterparties currently available in the network, and displays this value in the right panel.