### PR TITLE
testnet: Generate common dynamic pages at build time

### DIFF
--- a/testnet.renegade.fi/app/[base]/[quote]/page.tsx
+++ b/testnet.renegade.fi/app/[base]/[quote]/page.tsx
@@ -10,6 +10,15 @@ import RelayerStatusData from "@/components/banners/relayer-status-data"
 import AllTokensBanner from "@/components/banners/tokens-banner"
 import TradingBody from "@/components/trading-body"
 
+export function generateStaticParams() {
+  return DISPLAYED_TICKERS.map(([base, quote]) => {
+    return {
+      base,
+      quote,
+    }
+  })
+}
+
 const renegade = new Renegade({
   relayerHostname: env.NEXT_PUBLIC_RENEGADE_RELAYER_HOSTNAME,
   relayerHttpPort: 3000,


### PR DESCRIPTION
This PR uses the `generateStaticParams` function to [statically generate](https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#static-rendering-default) dynamic routes at build time instead of on-demand at request time.