### PR TITLE
testnet: Prevent duplicate listeners for price report

### DIFF
--- a/testnet.renegade.fi/app/providers.tsx
+++ b/testnet.renegade.fi/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import React from "react"
+import { ExchangeProvider } from "@/contexts/Exchange/exchange-context"
 import { OrderProvider } from "@/contexts/Order/order-context"
 import { RenegadeProvider } from "@/contexts/Renegade/renegade-context"
 import { env } from "@/env.mjs"
@@ -206,7 +207,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
               }}
             >
               <RenegadeProvider>
-                <OrderProvider>{children}</OrderProvider>
+                <ExchangeProvider>
+                  <OrderProvider>{children}</OrderProvider>
+                </ExchangeProvider>
               </RenegadeProvider>
             </ConnectKitProvider>
           </WagmiConfig>

--- a/testnet.renegade.fi/components/banners/live-price.tsx
+++ b/testnet.renegade.fi/components/banners/live-price.tsx
@@ -1,12 +1,12 @@
-import React from "react"
-import { PriceReport } from "@/types"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useExchange } from "@/contexts/Exchange/exchange-context"
 import { TriangleDownIcon, TriangleUpIcon } from "@chakra-ui/icons"
 import { Box, Flex, Text } from "@chakra-ui/react"
-import { CallbackId, Exchange, Token } from "@renegade-fi/renegade-js"
+import { Exchange } from "@renegade-fi/renegade-js"
 
 import { TICKER_TO_DEFAULT_DECIMALS } from "@/lib/tokens"
-import { renegade } from "@/app/providers"
 
+import { PriceReport } from "../../types"
 import { BannerSeparator } from "./banner-separator"
 
 const DEFAULT_PRICE_REPORT = {
@@ -20,7 +20,6 @@ const DEFAULT_PRICE_REPORT = {
   reportedTimestamp: 0,
 }
 
-const UPDATE_THRESHOLD_MS = 50
 interface LivePricesProps {
   baseTicker: string
   quoteTicker: string
@@ -32,282 +31,194 @@ interface LivePricesProps {
   shouldRotate?: boolean
   price?: number
 }
-interface LivePricesState {
-  fallbackPriceReport: PriceReport
-  previousPriceReport: PriceReport
-  currentPriceReport: PriceReport
-  callbackId?: CallbackId
-}
-// TODO: Initial price comes top down (data fetch server components), live price comes from leaves (this component)
-export class LivePrices extends React.Component<
-  LivePricesProps,
-  LivePricesState
-> {
-  constructor(props: LivePricesProps) {
-    super(props)
-    this.state = {
-      fallbackPriceReport: DEFAULT_PRICE_REPORT,
-      previousPriceReport: DEFAULT_PRICE_REPORT,
-      currentPriceReport: DEFAULT_PRICE_REPORT,
-    }
-    this.streamPriceReports = this.streamPriceReports.bind(this)
-    this.handlePriceReport = this.handlePriceReport.bind(this)
-  }
 
-  async componentDidMount() {
-    await this.queryFallbackPriceReport()
-    await this.streamPriceReports()
-  }
+export const LivePrices = ({
+  baseTicker,
+  quoteTicker,
+  exchange,
+  onlyShowPrice,
+  withCommas,
+  scaleBy,
+  isMobile,
+  shouldRotate,
+  price: priceProp,
+}: LivePricesProps) => {
+  const [fallbackPriceReport, setFallbackPriceReport] =
+    useState(DEFAULT_PRICE_REPORT)
+  const [previousPriceReport, setPreviousPriceReport] =
+    useState<PriceReport>(DEFAULT_PRICE_REPORT)
+  const [currentPriceReport, setCurrentPriceReport] =
+    useState<PriceReport>(DEFAULT_PRICE_REPORT)
 
-  async componentDidUpdate(prevProps: LivePricesProps) {
-    if (
-      prevProps.baseTicker === this.props.baseTicker &&
-      prevProps.quoteTicker === this.props.quoteTicker
-    ) {
-      return
-    }
-    if (!this.state.callbackId) {
-      return
-    }
-    renegade.releaseCallback(this.state.callbackId)
-    this.setState({
-      fallbackPriceReport: DEFAULT_PRICE_REPORT,
-      previousPriceReport: DEFAULT_PRICE_REPORT,
-      currentPriceReport: DEFAULT_PRICE_REPORT,
+  const { getPriceData, onRegisterPriceListener } = useExchange()
+  const priceReport = getPriceData(exchange, baseTicker, quoteTicker)
+
+  useEffect(() => {
+    if (!priceReport) return
+    setCurrentPriceReport((prev) => {
+      setPreviousPriceReport(prev)
+      return priceReport
     })
-    await this.queryFallbackPriceReport()
-    await this.streamPriceReports()
-  }
+  }, [priceReport])
 
-  async queryFallbackPriceReport() {
-    if (this.props.baseTicker === this.props.quoteTicker) {
-      return
-    }
-    const healthStates = await renegade.queryExchangeHealthStates(
-      new Token({ ticker: this.props.baseTicker }),
-      new Token({ ticker: this.props.quoteTicker })
-    )
-    let medianPriceReport = null
-    if (healthStates["median"]["Nominal"]) {
-      medianPriceReport = healthStates["median"]["Nominal"]
-    } else if (healthStates["median"]["DataTooStale"]) {
-      medianPriceReport = healthStates["median"]["DataTooStale"][0]
-    } else if (healthStates["median"]["TooMuchDeviation"]) {
-      medianPriceReport = healthStates["median"]["TooMuchDeviation"][0]
-    }
-    const healthStatesExchanges = healthStates["all_exchanges"]
-    const fallbackPriceReport =
-      {
-        median: medianPriceReport,
-        binance:
-          healthStatesExchanges["Binance"] &&
-          healthStatesExchanges["Binance"]["Nominal"],
-        coinbase:
-          healthStatesExchanges["Coinbase"] &&
-          healthStatesExchanges["Coinbase"]["Nominal"],
-        kraken:
-          healthStatesExchanges["Kraken"] &&
-          healthStatesExchanges["Kraken"]["Nominal"],
-        okx:
-          healthStatesExchanges["Okx"] &&
-          healthStatesExchanges["Okx"]["Nominal"],
-        uniswapv3:
-          healthStatesExchanges["UniswapV3"] &&
-          healthStatesExchanges["UniswapV3"]["Nominal"],
-      }[this.props.exchange] || DEFAULT_PRICE_REPORT
-    this.setState({ fallbackPriceReport })
-  }
-
-  async streamPriceReports() {
-    if (this.props.baseTicker === "USDC" || this.props.baseTicker === "USDT") {
-      return
-    }
-
-    // Keep track of the last update timestamp
-    let lastUpdate = 0
-
-    // Create a price report callback
-    const callback = (message: string) => {
-      const priceReport = JSON.parse(message) as PriceReport
-      // If the priceReport does not change the median price, ignore it
-      if (
-        this.state.currentPriceReport.midpointPrice ===
-        priceReport.midpointPrice
-      ) {
-        return
-      }
-      // If this price report was received too quickly after the previous, ignore it
-      const now = Date.now()
-      if (now - lastUpdate <= UPDATE_THRESHOLD_MS) {
-        return
-      }
-      lastUpdate = now
-      this.handlePriceReport(priceReport)
-    }
-    const callbackId = await renegade.registerPriceReportCallback(
-      callback,
-      this.props.exchange,
-      new Token({ ticker: this.props.baseTicker }),
-      new Token({ ticker: this.props.quoteTicker })
-    )
-    this.setState({ callbackId })
-  }
-
-  handlePriceReport(newPriceReport: PriceReport) {
-    this.setState({
-      currentPriceReport: newPriceReport,
-      previousPriceReport: this.state.currentPriceReport,
-    })
-  }
-
-  render() {
-    // Given the previous and current price reports, determine the displayed
-    // price and red/green fade class
-    let price = this.props.price
-    let priceStrClass = ""
-    if (this.state.currentPriceReport === DEFAULT_PRICE_REPORT) {
-      if (this.state.fallbackPriceReport !== DEFAULT_PRICE_REPORT) {
-        price = this.state.fallbackPriceReport.midpointPrice
-      }
-      // else if (
-      //   this.props.baseTicker === "USDC" ||
-      //   this.props.baseTicker === "USDT"
-      // ) {
-      //   price = 1
-      // } else {
-      //   price = 0
-      // }
-    } else if (this.state.previousPriceReport === DEFAULT_PRICE_REPORT) {
-      price = this.state.currentPriceReport.midpointPrice
-    } else {
-      price = this.state.currentPriceReport.midpointPrice
-      priceStrClass =
-        this.state.currentPriceReport.midpointPrice >
-        this.state.previousPriceReport.midpointPrice
-          ? "fade-green-to-white"
-          : "fade-red-to-white"
-    }
-    price = price || 0
-
-    // If the caller supplied a scaleBy prop, scale the price appropriately
-    if (this.props.scaleBy !== undefined) {
-      price *= this.props.scaleBy
-    }
-
-    // Format the price as a string
-    let trailingDecimals: number
-    const baseDefaultDecimals =
-      TICKER_TO_DEFAULT_DECIMALS[this.props.baseTicker]
-    if (this.props.quoteTicker !== "USDC") {
-      trailingDecimals = 2
+  const baseDefaultDecimals = TICKER_TO_DEFAULT_DECIMALS[baseTicker]
+  const trailingDecimals = useMemo(() => {
+    if (quoteTicker !== "USDC") {
+      return 2
     } else if (baseDefaultDecimals >= 3) {
-      trailingDecimals = 2
+      return 2
     } else {
-      trailingDecimals = Math.abs(baseDefaultDecimals) + 2
+      return Math.abs(baseDefaultDecimals) + 2
     }
-    let priceStr = price?.toFixed(trailingDecimals) || ""
-    if (
-      (this.state.currentPriceReport == DEFAULT_PRICE_REPORT ||
-        this.props.scaleBy === 0) &&
-      baseDefaultDecimals > 0
-    ) {
-      const leadingDecimals = priceStr.split(".")[0].length
-      priceStr =
-        "0".repeat(Math.max(0, baseDefaultDecimals - leadingDecimals)) +
-        priceStr
-    }
-    // Add commmas to the price string
-    if (this.props.withCommas) {
-      const priceStrParts = priceStr.split(".")
-      priceStrParts[0] = priceStrParts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",")
-      priceStr = priceStrParts.join(".")
-    }
+  }, [baseDefaultDecimals, quoteTicker])
 
-    if (this.props.onlyShowPrice) {
-      return <Text opacity={price == 0 ? "40%" : "inherit"}>${priceStr}</Text>
-    }
+  const callbackIdRef = useRef(false)
+  useEffect(() => {
+    if (callbackIdRef.current) return
+    onRegisterPriceListener(
+      exchange,
+      baseTicker,
+      quoteTicker,
+      trailingDecimals
+    ).then((callbackId) => {
+      if (callbackId) {
+        callbackIdRef.current = true
+      }
+    })
+  }, [
+    baseTicker,
+    quoteTicker,
+    onRegisterPriceListener,
+    exchange,
+    trailingDecimals,
+  ])
 
-    const key = [
-      this.props.baseTicker,
-      this.props.quoteTicker,
-      this.state.currentPriceReport.localTimestamp,
-    ].join("_")
-
-    // Create the icon to display next to the price
-    let priceIcon: React.ReactElement
-    if (priceStrClass === "") {
-      priceIcon = (
-        <TriangleUpIcon
-          width="12px"
-          height="12px"
-          opacity="0%"
-          key={key + "_icon"}
-        />
-      )
-    } else if (priceStrClass === "fade-green-to-white") {
-      priceIcon = (
-        <TriangleUpIcon
-          width="12px"
-          height="12px"
-          className="fade-green-to-transparent"
-          key={key + "_icon"}
-        />
-      )
+  // Given the previous and current price reports, determine the displayed
+  // price and red/green fade class
+  let price = priceProp
+  let priceStrClass = ""
+  if (currentPriceReport === DEFAULT_PRICE_REPORT) {
+    if (fallbackPriceReport !== DEFAULT_PRICE_REPORT) {
+      price = fallbackPriceReport.midpointPrice
+    } else if (baseTicker === "USDC" || baseTicker === "USDT") {
+      price = 1
     } else {
-      priceIcon = (
-        <TriangleDownIcon
-          width="12px"
-          height="12px"
-          className="fade-red-to-transparent"
-          key={key + "_icon"}
-        />
-      )
+      price = 0
     }
+  } else if (previousPriceReport === DEFAULT_PRICE_REPORT) {
+    price = currentPriceReport.midpointPrice
+  } else {
+    price = currentPriceReport.midpointPrice
+    priceStrClass =
+      currentPriceReport.midpointPrice > previousPriceReport.midpointPrice
+        ? "fade-green-to-white"
+        : "fade-red-to-white"
+  }
+  price = price || 0
 
-    return (
-      <>
-        <Flex
-          className={priceStrClass}
-          key={key + "_price"}
-          sx={
-            this.props.isMobile
-              ? {
-                  writingMode: "vertical-rl",
-                  textOrientation: "sideways",
-                }
-              : undefined
-          }
-          alignItems="center"
-          justifyContent="center"
-          flexGrow="1"
-          width={this.props.isMobile ? "100%" : undefined}
-          color="white.80"
-          fontFamily="Favorit Mono"
-          lineHeight="1"
-          opacity={price == 0 ? "20%" : "100%"}
-          _hover={{ textDecoration: "none" }}
-          transform={
-            this.props.isMobile && this.props.shouldRotate
-              ? "rotate(180deg)"
-              : undefined
-          }
-        >
-          ${priceStr}
-        </Flex>
-        <Flex
-          position="relative"
-          alignItems="center"
-          justifyContent="center"
-          width={this.props.isMobile ? "100%" : undefined}
-          height="100%"
-          _hover={{ textDecoration: "none" }}
-        >
-          <Box position="absolute">
-            <BannerSeparator />
-          </Box>
-          {priceIcon}
-        </Flex>
-      </>
+  // If the caller supplied a scaleBy prop, scale the price appropriately
+  if (scaleBy !== undefined) {
+    price *= scaleBy
+  }
+
+  // Format the price as a string
+  let priceStr = price?.toFixed(trailingDecimals) || ""
+  if (
+    (currentPriceReport === DEFAULT_PRICE_REPORT || scaleBy === 0) &&
+    baseDefaultDecimals > 0
+  ) {
+    const leadingDecimals = priceStr.split(".")[0].length
+    priceStr =
+      "0".repeat(Math.max(0, baseDefaultDecimals - leadingDecimals)) + priceStr
+  }
+
+  // Add commas to the price string
+  if (withCommas) {
+    const priceStrParts = priceStr.split(".")
+    priceStrParts[0] = priceStrParts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",")
+    priceStr = priceStrParts.join(".")
+  }
+
+  const priceOpacity = price === 0 ? "40%" : "inherit"
+
+  if (onlyShowPrice) {
+    return <Text opacity={priceOpacity}>${priceStr}</Text>
+  }
+
+  const key = [baseTicker, quoteTicker, currentPriceReport.localTimestamp].join(
+    "_"
+  )
+
+  // Create the icon to display next to the price
+  let priceIcon
+  if (priceStrClass === "") {
+    priceIcon = (
+      <TriangleUpIcon
+        width="12px"
+        height="12px"
+        opacity="0%"
+        key={key + "_icon"}
+      />
+    )
+  } else if (priceStrClass === "fade-green-to-white") {
+    priceIcon = (
+      <TriangleUpIcon
+        width="12px"
+        height="12px"
+        className="fade-green-to-transparent"
+        key={key + "_icon"}
+      />
+    )
+  } else {
+    priceIcon = (
+      <TriangleDownIcon
+        width="12px"
+        height="12px"
+        className="fade-red-to-transparent"
+        key={key + "_icon"}
+      />
     )
   }
+
+  return (
+    <>
+      <Flex
+        className={priceStrClass}
+        key={key + "_price"}
+        sx={
+          isMobile
+            ? {
+                writingMode: "vertical-rl",
+                textOrientation: "sideways",
+              }
+            : undefined
+        }
+        alignItems="center"
+        justifyContent="center"
+        flexGrow="1"
+        width={isMobile ? "100%" : undefined}
+        color="white.80"
+        fontFamily="Favorit Mono"
+        lineHeight="1"
+        opacity={price === 0 ? "20%" : "100%"}
+        _hover={{ textDecoration: "none" }}
+        transform={isMobile && shouldRotate ? "rotate(180deg)" : undefined}
+      >
+        ${priceStr}
+      </Flex>
+      <Flex
+        position="relative"
+        alignItems="center"
+        justifyContent="center"
+        width={isMobile ? "100%" : undefined}
+        height="100%"
+        _hover={{ textDecoration: "none" }}
+      >
+        <Box position="absolute">
+          <BannerSeparator />
+        </Box>
+        {priceIcon}
+      </Flex>
+    </>
+  )
 }

--- a/testnet.renegade.fi/contexts/Exchange/exchange-context.tsx
+++ b/testnet.renegade.fi/contexts/Exchange/exchange-context.tsx
@@ -1,0 +1,134 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+import { CallbackId, Exchange, Token } from "@renegade-fi/renegade-js"
+
+import { renegade } from "@/app/providers"
+
+import { PriceReport } from "../Renegade/types"
+import { ExchangeContextValue } from "./types"
+
+type ExchangeProviderProps = { children: React.ReactNode }
+
+const ExchangeContext = createContext<ExchangeContextValue | undefined>(
+  undefined
+)
+
+function ExchangeProvider({ children }: ExchangeProviderProps) {
+  const callbackIdRefs = useRef<{ [key: string]: CallbackId }>({})
+  const [priceReport, setPriceReport] = useState<{
+    [key: string]: PriceReport
+  }>({})
+  // Queue is used to prevent multiple successive calls
+  const queue = useRef<Set<string>>(new Set())
+
+  const handlePriceListener = useCallback(
+    async (
+      exchange: Exchange,
+      base: string,
+      quote: string,
+      decimals?: number
+    ) => {
+      const key = getKey(exchange, base, quote)
+
+      if (callbackIdRefs.current[key]) {
+        return
+      }
+      if (queue.current.has(key)) {
+        return
+      }
+      queue.current.add(key)
+
+      let lastUpdate = 0
+
+      const UPDATE_THRESHOLD_MS = 50
+      const callbackId = await renegade
+        .registerPriceReportCallback(
+          (message: string) => {
+            const priceReport = JSON.parse(message) as PriceReport
+            const now = Date.now()
+            if (now - lastUpdate <= UPDATE_THRESHOLD_MS) {
+              return
+            }
+            lastUpdate = now
+
+            // Store the price report if it's different from the previous one
+            setPriceReport((prev) => {
+              if (
+                !prev[key] ||
+                prev[key].midpointPrice.toFixed(decimals || 2) !==
+                  priceReport.midpointPrice.toFixed(decimals || 2)
+              ) {
+                return {
+                  ...prev,
+                  [key]: priceReport,
+                }
+              }
+              return prev
+            })
+          },
+          exchange,
+          new Token({ ticker: base }),
+          new Token({ ticker: quote })
+        )
+        .then((callbackId) => {
+          if (callbackId) {
+            callbackIdRefs.current[key] = callbackId
+            return callbackId
+          }
+        })
+        .catch(() => {
+          return undefined
+        })
+      queue.current.delete(key)
+      return callbackId
+    },
+    []
+  )
+
+  useEffect(() => {
+    return () => {
+      Object.values(callbackIdRefs.current).forEach((callbackId) => {
+        renegade.releaseCallback(callbackId)
+      })
+      callbackIdRefs.current = {}
+    }
+  }, [handlePriceListener])
+
+  return (
+    <ExchangeContext.Provider
+      value={{
+        onRegisterPriceListener: handlePriceListener,
+        getPriceData: (
+          exchange: Exchange,
+          baseTicker: string,
+          quoteTicker: string
+        ): PriceReport | undefined => {
+          const key = getKey(exchange, baseTicker, quoteTicker)
+          return priceReport[key]
+        },
+      }}
+    >
+      {children}
+    </ExchangeContext.Provider>
+  )
+}
+
+function useExchange() {
+  const context = useContext(ExchangeContext)
+  if (context === undefined) {
+    throw new Error("useExchange must be used within a ExchangeProvider")
+  }
+  return context
+}
+
+export { ExchangeProvider, useExchange }
+
+function getKey(exchange: Exchange, base: string, quote: string) {
+  return `${exchange}-${base}-${quote}`
+}

--- a/testnet.renegade.fi/contexts/Exchange/types.ts
+++ b/testnet.renegade.fi/contexts/Exchange/types.ts
@@ -1,0 +1,16 @@
+import { PriceReport } from "@/types"
+import { CallbackId, Exchange } from "@renegade-fi/renegade-js"
+
+export interface ExchangeContextValue {
+  onRegisterPriceListener: (
+    exchange: Exchange,
+    base: string,
+    quote: string,
+    decimals?: number
+  ) => Promise<CallbackId | undefined>
+  getPriceData: (
+    exchange: Exchange,
+    base: string,
+    quote: string
+  ) => PriceReport | undefined
+}


### PR DESCRIPTION
This PR creates an `ExchangeContext` that keeps track of listeners to specific token pairs (and exchanges). It ensures that new requests to listen to a token are created iff a listener does not already exist, and provides a way to access the price for child components. # listeners goes from 37 -> 13