### PR TITLE
testnet: Fix midpoint price in OrderStepper

### DIFF
--- a/testnet.renegade.fi/components/steppers/order-stepper/order-stepper.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/order-stepper.tsx
@@ -58,19 +58,23 @@ export enum Step {
 }
 
 interface StepperContextType {
-  onNext: () => void
+  midpoint: number
   onBack: () => void
-  step: Step
-  setStep: (step: Step) => void
   onClose: () => void
+  onNext: () => void
+  setMidpoint: (midpoint: number) => void
+  setStep: (step: Step) => void
+  step: Step
 }
 
 const StepperContext = createContext<StepperContextType>({
-  onNext: () => {},
+  midpoint: 0,
   onBack: () => {},
-  step: Step.DEFAULT,
-  setStep: () => {},
   onClose: () => {},
+  onNext: () => {},
+  setMidpoint: () => {},
+  setStep: () => {},
+  step: Step.DEFAULT,
 })
 
 export const useStepper = () => useContext(StepperContext)
@@ -83,6 +87,7 @@ const StepperProvider = ({
   onClose: () => void
 }) => {
   const [step, setStep] = useState(Step.DEFAULT)
+  const [midpoint, setMidpoint] = useState(0)
 
   const handleNext = () => {
     setStep(step + 1)
@@ -94,7 +99,15 @@ const StepperProvider = ({
 
   return (
     <StepperContext.Provider
-      value={{ onNext: handleNext, onBack: handleBack, step, setStep, onClose }}
+      value={{
+        midpoint,
+        onBack: handleBack,
+        onClose,
+        onNext: handleNext,
+        setMidpoint,
+        setStep,
+        step,
+      }}
     >
       {children}
     </StepperContext.Provider>

--- a/testnet.renegade.fi/components/steppers/order-stepper/steps/exit-step.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/steps/exit-step.tsx
@@ -14,7 +14,7 @@ import { useStepper } from "../order-stepper"
 
 export default function ExitStep() {
   const { baseTicker, baseTokenAmount, direction } = useOrder()
-  const { onClose } = useStepper()
+  const { midpoint, onClose } = useStepper()
   const [isHovered, setIsHovered] = useState(true)
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -83,7 +83,9 @@ export default function ExitStep() {
               <Text color="white.50">
                 {direction === "buy" ? "Paid at most" : "Received at least"}
               </Text>
-              <Text variant={isHovered ? undefined : "blurred"}>???? USDC</Text>
+              <Text variant={isHovered ? undefined : "blurred"}>
+                {midpoint.toFixed(2)}&nbsp;USDC
+              </Text>
             </Flex>
           </Flex>
         </Flex>

--- a/testnet.renegade.fi/components/steppers/order-stepper/steps/loading-step.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/steps/loading-step.tsx
@@ -9,8 +9,9 @@ export default function LoadingStep() {
   const { onNext } = useStepper()
   const { taskState, taskType } = useRenegade()
   useEffect(() => {
-    if (taskType === TaskType.PlaceOrder && taskState === TaskState.Completed)
+    if (taskType === TaskType.PlaceOrder && taskState === TaskState.Completed) {
       onNext()
+    }
   }, [onNext, taskState, taskType])
 
   return (

--- a/testnet.renegade.fi/contexts/Order/order-context.tsx
+++ b/testnet.renegade.fi/contexts/Order/order-context.tsx
@@ -37,7 +37,6 @@ function OrderProvider({ children }: OrderProviderProps) {
   }
   const [baseTokenAmount, setBaseTokenAmount] = useState(0)
   const { accountId, setTask } = useRenegade()
-  const [midpointPrice, setMidpointPrice] = useState<number>()
 
   const [orderBook, setOrderBook] = useState<
     Record<OrderId, CounterpartyOrder>
@@ -120,17 +119,15 @@ function OrderProvider({ children }: OrderProviderProps) {
   return (
     <OrderStateContext.Provider
       value={{
-        direction,
-        setDirection,
         baseTicker,
-        setBaseToken: handleSetBaseToken,
-        quoteTicker,
-        setQuoteToken: handleSetQuoteToken,
         baseTokenAmount,
-        setBaseTokenAmount,
-        setMidpointPrice,
+        direction,
         onPlaceOrder: handlePlaceOrder,
-        midpointPrice,
+        quoteTicker,
+        setBaseToken: handleSetBaseToken,
+        setBaseTokenAmount,
+        setDirection,
+        setQuoteToken: handleSetQuoteToken,
       }}
     >
       {children}

--- a/testnet.renegade.fi/contexts/Order/types.ts
+++ b/testnet.renegade.fi/contexts/Order/types.ts
@@ -4,15 +4,13 @@ export enum Direction {
 }
 
 export interface OrderContextValue {
-  direction: Direction
-  setDirection: (direction: Direction) => void
   baseTicker: string
+  baseTokenAmount: number
+  direction: Direction
+  onPlaceOrder: () => void
   quoteTicker: string
   setBaseToken: (token: string) => void
-  setQuoteToken: (token: string) => void
-  baseTokenAmount: number
   setBaseTokenAmount: (amount: number) => void
-  setMidpointPrice: (price?: number) => void
-  onPlaceOrder: () => void
-  midpointPrice?: number
+  setDirection: (direction: Direction) => void
+  setQuoteToken: (token: string) => void
 }


### PR DESCRIPTION
`order-stepper.tsx`
- add midpoint state variable to track midpoint

`confirm-step.tsx`
- fetch midpoint price from `ExchangeContext` and display
- set midpoint state variable for use in other steps

`exit-step.tsx`
- display midpoint state variable

General tidying up of other components that had artifacts of previous implementations.