### PR TITLE
testnet: Add listeners cleanup functions, add network listener

### DIFF
--- a/testnet.renegade.fi/contexts/Order/order-context.tsx
+++ b/testnet.renegade.fi/contexts/Order/order-context.tsx
@@ -90,9 +90,9 @@ function OrderProvider({ children }: OrderProviderProps) {
     }
     handleNetworkListener()
     return () => {
-      if (orderCallbackId.current) {
-        renegade.releaseCallback(orderCallbackId.current)
-      }
+      if (!orderCallbackId.current) return
+      renegade.releaseCallback(orderCallbackId.current)
+      orderCallbackId.current = undefined
     }
   }, [])
 


### PR DESCRIPTION
This PR ensures that cleanup functions for various listeners are consistent, and also adds a network listener to sync the number of counterparties.