### PR TITLE
testnet: Fixes for demo

### DIFF
--- a/testnet.renegade.fi/app/[base]/[quote]/main.tsx
+++ b/testnet.renegade.fi/app/[base]/[quote]/main.tsx
@@ -6,6 +6,7 @@ import { ViewEnum } from "@/contexts/Renegade/types"
 import { useDisclosure } from "@chakra-ui/react"
 import { useAccount } from "wagmi"
 
+import { safeLocalStorageGetItem } from "@/lib/utils"
 import { TestnetStepper } from "@/components/steppers/testnet-stepper/testnet-stepper"
 import { DepositBody } from "@/app/[base]/[quote]/deposit"
 import { TradingBody } from "@/app/[base]/[quote]/trading"
@@ -19,14 +20,9 @@ export function Main() {
     [ViewEnum.DEPOSIT]: DepositBody,
   }[view]
 
-  const handleClose = () => {
-    onClose()
-    localStorage.setItem(`${address}-preloaded`, "true")
-  }
-
   useEffect(() => {
-    const preloaded = localStorage.getItem(`${address}-preloaded`)
-    if (!preloaded && accountId) {
+    const preloaded = safeLocalStorageGetItem(`${address}-preloaded`)
+    if (address && !preloaded && accountId) {
       onOpen()
     }
   }, [accountId, address, balances, onOpen])
@@ -34,7 +30,7 @@ export function Main() {
   return (
     <>
       <CurrentView />
-      {isOpen && <TestnetStepper onClose={handleClose} />}
+      {isOpen && <TestnetStepper onClose={onClose} />}
     </>
   )
 }

--- a/testnet.renegade.fi/app/[base]/[quote]/trading.tsx
+++ b/testnet.renegade.fi/app/[base]/[quote]/trading.tsx
@@ -5,7 +5,15 @@ import { useOrder } from "@/contexts/Order/order-context"
 import { Direction } from "@/contexts/Order/types"
 import { useRenegade } from "@/contexts/Renegade/renegade-context"
 import { ChevronDownIcon } from "@chakra-ui/icons"
-import { Box, Flex, HStack, Input, Text, useDisclosure } from "@chakra-ui/react"
+import {
+  Box,
+  Flex,
+  HStack,
+  Input,
+  Portal,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react"
 import { Exchange } from "@renegade-fi/renegade-js"
 
 import { LivePrices } from "@/components/banners/live-price"
@@ -192,9 +200,11 @@ export function TradingBody() {
           buySellSelectableCoords={buySellSelectableCoords.current}
           quoteTokenSelectableCoords={quoteTokenSelectableCoords.current}
         />
-        <Box position="absolute" right="0" bottom="0">
-          {taskState && taskType && <TaskStatus />}
-        </Box>
+        <Portal>
+          <Box position="absolute" zIndex={1500} right="0" bottom="0">
+            {taskState && taskType && <TaskStatus />}
+          </Box>
+        </Portal>
       </Flex>
       <TokenSelectModal
         isOpen={tokenMenuIsOpen}

--- a/testnet.renegade.fi/components/banners/median-banner.tsx
+++ b/testnet.renegade.fi/components/banners/median-banner.tsx
@@ -109,7 +109,6 @@ export function ExchangeConnectionTriple(props: ExchangeConnectionTripleProps) {
   let showPrice: boolean
   let connectionText: string
   let textVariant: string
-  // TODO: update state to reflect cache behavior
   if (healthState === HealthState.enum.Connecting) {
     showPrice = true
     connectionText = "LIVE"

--- a/testnet.renegade.fi/components/main-nav.tsx
+++ b/testnet.renegade.fi/components/main-nav.tsx
@@ -21,7 +21,7 @@ import {
   useEnsName as useEnsNameWagmi,
 } from "wagmi"
 
-import { SignInModal } from "@/components/modals/signin-modal"
+import { CreateStepper } from "@/components/steppers/create-stepper/create-stepper"
 
 function FancyUnderline(props: { children: React.ReactElement }) {
   const [isHovering, setIsHovering] = React.useState(false)
@@ -167,10 +167,12 @@ function SignInButton() {
   }
 
   return (
-    <Button onClick={onOpen} variant="wallet-connect">
-      {buttonContent}
-      <SignInModal isOpen={isOpen} onClose={onClose} />
-    </Button>
+    <>
+      <Button onClick={onOpen} variant="wallet-connect">
+        {buttonContent}
+      </Button>
+      {isOpen && <CreateStepper onClose={onClose} />}
+    </>
   )
 }
 

--- a/testnet.renegade.fi/components/steppers/create-stepper/create-stepper.tsx
+++ b/testnet.renegade.fi/components/steppers/create-stepper/create-stepper.tsx
@@ -1,0 +1,108 @@
+import React, { createContext, useContext, useState } from "react"
+import {
+  Fade,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/react"
+
+import { DefaultStep } from "@/components/steppers/create-stepper/steps/default-step"
+import { LoadingStep } from "@/components/steppers/create-stepper/steps/loading-step"
+
+const CreateStepperInner = () => {
+  const { step, onClose } = useStepper()
+
+  return (
+    <Modal
+      closeOnOverlayClick={false}
+      isCentered
+      isOpen
+      onClose={onClose}
+      size="sm"
+    >
+      <ModalOverlay
+        background="rgba(0, 0, 0, 0.25)"
+        backdropFilter="blur(8px)"
+      />
+      <ModalContent height="212px" background="surfaces.1" borderRadius="10">
+        {step === Step.DEFAULT && (
+          <ModalHeader paddingBottom="0">Unlock your Wallet</ModalHeader>
+        )}
+        <Fade
+          transition={{ enter: { duration: 0.25 } }}
+          in={step === Step.DEFAULT}
+        >
+          {step === Step.DEFAULT && <DefaultStep />}
+        </Fade>
+        <Fade
+          transition={{ enter: { duration: 0.25 } }}
+          in={step === Step.LOADING}
+        >
+          {step === Step.LOADING && <LoadingStep />}
+        </Fade>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export enum Step {
+  DEFAULT,
+  LOADING,
+}
+
+const StepperContext = createContext<{
+  onBack: () => void
+  onClose: () => void
+  onNext: () => void
+  setStep: (step: Step) => void
+  step: Step
+}>({
+  onBack: () => {},
+  onClose: () => {},
+  onNext: () => {},
+  setStep: () => {},
+  step: Step.DEFAULT,
+})
+
+export const useStepper = () => useContext(StepperContext)
+
+const StepperProvider = ({
+  children,
+  onClose,
+}: {
+  children: React.ReactNode
+  onClose: () => void
+}) => {
+  const [step, setStep] = useState(Step.DEFAULT)
+
+  const handleNext = () => {
+    setStep(step + 1)
+  }
+
+  const handleBack = () => {
+    setStep(step - 1)
+  }
+
+  return (
+    <StepperContext.Provider
+      value={{
+        onBack: handleBack,
+        onClose,
+        onNext: handleNext,
+        setStep,
+        step,
+      }}
+    >
+      {children}
+    </StepperContext.Provider>
+  )
+}
+
+export function CreateStepper({ onClose }: { onClose: () => void }) {
+  return (
+    <StepperProvider onClose={onClose}>
+      <CreateStepperInner />
+    </StepperProvider>
+  )
+}

--- a/testnet.renegade.fi/components/steppers/create-stepper/steps/default-step.tsx
+++ b/testnet.renegade.fi/components/steppers/create-stepper/steps/default-step.tsx
@@ -1,0 +1,93 @@
+import { useRenegade } from "@/contexts/Renegade/renegade-context"
+import {
+  Button,
+  Flex,
+  HStack,
+  ModalBody,
+  Spinner,
+  Text,
+} from "@chakra-ui/react"
+import { Keychain } from "@renegade-fi/renegade-js"
+import { Unplug } from "lucide-react"
+import {
+  useAccount as useAccountWagmi,
+  useDisconnect as useDisconnectWagmi,
+  useSignMessage as useSignMessageWagmi,
+} from "wagmi"
+
+import { useStepper } from "@/components/steppers/create-stepper/create-stepper"
+import { client } from "@/app/providers"
+
+export function DefaultStep() {
+  const { onClose, onNext } = useStepper()
+  const { address } = useAccountWagmi()
+  const { accountId, setAccount } = useRenegade()
+  const { isLoading, signMessage } = useSignMessageWagmi({
+    message: "Unlock your Renegade account.\nTestnet v0",
+    async onSuccess(data, variables) {
+      const valid = await client.verifyMessage({
+        address: address ?? `0x`,
+        message: variables.message,
+        signature: data,
+      })
+      if (!valid) {
+        throw new Error("Invalid signature")
+      }
+      setAccount(accountId, new Keychain({ seed: data }))
+      onNext()
+    },
+  })
+  const { disconnect } = useDisconnectWagmi()
+
+  return (
+    <>
+      <ModalBody>
+        <Flex justifyContent="center" flexDirection="column" gap="4">
+          <Text color="white.60" fontSize="0.9em">
+            To trade on Renegade, we require a one-time signature to unlock and
+            create your wallet.
+          </Text>
+          <Button
+            color="white.90"
+            fontWeight="800"
+            transition="0.2s"
+            onClick={() => signMessage()}
+          >
+            <HStack spacing="10px">
+              <Spinner
+                width={isLoading ? "17px" : "0px"}
+                height={isLoading ? "17px" : "0px"}
+                opacity={isLoading ? 1 : 0}
+                transition="0.2s"
+                speed="0.8s"
+              />
+              <Text>Sign in to Renegade</Text>
+            </HStack>
+          </Button>
+          <Button
+            padding="0"
+            color="white.50"
+            fontFamily="Favorit"
+            fontSize="1.05em"
+            fontWeight="400"
+            disabled={isLoading}
+            onClick={() => {
+              disconnect()
+              onClose()
+            }}
+            variant="transparent"
+          >
+            <HStack spacing="4px">
+              <Unplug size={18} />
+              <Text>
+                Disconnect L1 address 0x
+                {address ? address.slice(2, 6) : "????"}
+                ..
+              </Text>
+            </HStack>
+          </Button>
+        </Flex>
+      </ModalBody>
+    </>
+  )
+}

--- a/testnet.renegade.fi/components/steppers/create-stepper/steps/loading-step.tsx
+++ b/testnet.renegade.fi/components/steppers/create-stepper/steps/loading-step.tsx
@@ -2,23 +2,21 @@ import { useEffect } from "react"
 import { useRenegade } from "@/contexts/Renegade/renegade-context"
 import { TaskState, TaskType } from "@/contexts/Renegade/types"
 import { Flex, ModalBody, ModalFooter, Spinner, Text } from "@chakra-ui/react"
-import { useAccount } from "wagmi"
 
-import { safeLocalStorageSetItem } from "@/lib/utils"
-
-import { useStepper } from "../testnet-stepper"
+import { useStepper } from "../create-stepper"
 
 export function LoadingStep() {
   const { onNext } = useStepper()
   const { taskType, taskState } = useRenegade()
-  const { address } = useAccount()
 
   useEffect(() => {
-    if (taskType === TaskType.Deposit && taskState === TaskState.Completed) {
-      safeLocalStorageSetItem(`${address}-preloaded`, "true")
+    if (
+      taskType === TaskType.InitializeAccount &&
+      taskState === TaskState.Completed
+    ) {
       onNext()
     }
-  }, [address, onNext, taskState, taskType])
+  }, [onNext, taskState, taskType])
 
   return (
     <>
@@ -29,6 +27,7 @@ export function LoadingStep() {
           flexDirection="column"
           gap="48px"
           textAlign="center"
+          marginY="12"
         >
           <Text
             color="white.50"
@@ -36,7 +35,7 @@ export function LoadingStep() {
             fontSize="1.3em"
             fontWeight="200"
           >
-            Deposit in progress...
+            Creating your account...
           </Text>
           <Spinner />
         </Flex>

--- a/testnet.renegade.fi/components/steppers/deposit-stepper/deposit-stepper.tsx
+++ b/testnet.renegade.fi/components/steppers/deposit-stepper/deposit-stepper.tsx
@@ -23,18 +23,21 @@ const DepositStepperInner = () => {
       <ModalContent background="surfaces.1" borderRadius="10px" paddingY="6">
         <Flex justifyContent="center" flexDirection="column" height="288px">
           <Fade
-            transition={{ enter: { duration: 1 } }}
+            transition={{ enter: { duration: 0.25 } }}
             in={step === Step.DEFAULT}
           >
             {step === Step.DEFAULT && <DefaultStep />}
           </Fade>
           <Fade
-            transition={{ enter: { duration: 1 } }}
+            transition={{ enter: { duration: 0.25 } }}
             in={step === Step.LOADING}
           >
             {step === Step.LOADING && <LoadingStep />}
           </Fade>
-          <Fade transition={{ enter: { duration: 1 } }} in={step === Step.EXIT}>
+          <Fade
+            transition={{ enter: { duration: 0.25 } }}
+            in={step === Step.EXIT}
+          >
             {step === Step.EXIT && <ExitStep />}
           </Fade>
         </Flex>

--- a/testnet.renegade.fi/components/steppers/deposit-stepper/steps/default-step.tsx
+++ b/testnet.renegade.fi/components/steppers/deposit-stepper/steps/default-step.tsx
@@ -24,7 +24,6 @@ export function DefaultStep() {
 
   const handleDeposit = async () => {
     if (!accountId) return
-    onNext()
     renegade.task
       .deposit(
         accountId,
@@ -32,6 +31,7 @@ export function DefaultStep() {
         BigInt(baseTokenAmount)
       )
       .then(([taskId]) => setTask(taskId, TaskType.Deposit))
+      .then(() => onNext())
   }
 
   return (

--- a/testnet.renegade.fi/components/steppers/order-stepper/order-stepper.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/order-stepper.tsx
@@ -23,18 +23,21 @@ const OrderStepperInner = () => {
       <ModalContent background="surfaces.1" borderRadius="10px">
         <Flex justifyContent="center" flexDirection="column" height="348px">
           <Fade
-            transition={{ enter: { duration: 1 } }}
+            transition={{ enter: { duration: 0.25 } }}
             in={step === Step.DEFAULT}
           >
             {step === Step.DEFAULT && <ConfirmStep />}
           </Fade>
           <Fade
-            transition={{ enter: { duration: 1 } }}
+            transition={{ enter: { duration: 0.25 } }}
             in={step === Step.LOADING}
           >
             {step === Step.LOADING && <LoadingStep />}
           </Fade>
-          <Fade transition={{ enter: { duration: 1 } }} in={step === Step.EXIT}>
+          <Fade
+            transition={{ enter: { duration: 0.25 } }}
+            in={step === Step.EXIT}
+          >
             {step === Step.EXIT && <ExitStep />}
           </Fade>
         </Flex>

--- a/testnet.renegade.fi/components/steppers/testnet-stepper/steps/default-step.tsx
+++ b/testnet.renegade.fi/components/steppers/testnet-stepper/steps/default-step.tsx
@@ -19,11 +19,12 @@ export function DefaultStep() {
   const { accountId, setTask } = useRenegade()
   const { onNext, setTicker, ticker } = useStepper()
 
+  const amount = ticker === "USDC" ? 10000 : 10
+
   const handleDeposit = async () => {
     if (!accountId) return
-    onNext()
     renegade.task
-      .deposit(accountId, new Token({ ticker }), BigInt(1000))
+      .deposit(accountId, new Token({ ticker }), BigInt(amount))
       .then(([taskId]) => setTask(taskId, TaskType.Deposit))
       .then(() => onNext())
   }
@@ -56,7 +57,7 @@ export function DefaultStep() {
             onClick={() => setTicker((t) => (t === "USDC" ? "WETH" : "USDC"))}
           >
             <Text fontFamily="Aime" fontSize="3em" fontWeight="700">
-              {`1000 ${ticker}`}
+              {`${amount} ${ticker}`}
             </Text>
             <Repeat2 size={24} />
           </HStack>

--- a/testnet.renegade.fi/components/steppers/testnet-stepper/steps/exit-step.tsx
+++ b/testnet.renegade.fi/components/steppers/testnet-stepper/steps/exit-step.tsx
@@ -1,3 +1,5 @@
+import { useOrder } from "@/contexts/Order/order-context"
+import { Direction } from "@/contexts/Order/types"
 import { ArrowForwardIcon } from "@chakra-ui/icons"
 import {
   Button,
@@ -12,6 +14,7 @@ import {
 import { useStepper } from "../testnet-stepper"
 
 export function ExitStep() {
+  const { setDirection } = useOrder()
   const { onClose, ticker } = useStepper()
   return (
     <>
@@ -32,7 +35,7 @@ export function ExitStep() {
             Your account has been funded with
           </Text>
           <Text fontFamily="Aime" fontSize="3em" fontWeight="700">
-            {`1000 ${ticker}`}
+            {`${ticker === "USDC" ? "10000" : "10"} ${ticker}`}
           </Text>
         </Flex>
       </ModalBody>
@@ -55,7 +58,10 @@ export function ExitStep() {
           }}
           transition="0.15s"
           backgroundColor="transparent"
-          onClick={onClose}
+          onClick={() => {
+            setDirection(ticker === "USDC" ? Direction.BUY : Direction.SELL)
+            onClose()
+          }}
         >
           <HStack spacing="4px">
             <Text>Trade</Text>

--- a/testnet.renegade.fi/components/steppers/testnet-stepper/testnet-stepper.tsx
+++ b/testnet.renegade.fi/components/steppers/testnet-stepper/testnet-stepper.tsx
@@ -23,18 +23,21 @@ const TestnetStepperInner = () => {
       <ModalContent background="surfaces.1" borderRadius="10">
         <Flex justifyContent="center" flexDirection="column" height="288px">
           <Fade
-            transition={{ enter: { duration: 1 } }}
+            transition={{ enter: { duration: 0.25 } }}
             in={step === Step.DEFAULT}
           >
             {step === Step.DEFAULT && <DefaultStep />}
           </Fade>
           <Fade
-            transition={{ enter: { duration: 1 } }}
+            transition={{ enter: { duration: 0.25 } }}
             in={step === Step.LOADING}
           >
             {step === Step.LOADING && <LoadingStep />}
           </Fade>
-          <Fade transition={{ enter: { duration: 1 } }} in={step === Step.EXIT}>
+          <Fade
+            transition={{ enter: { duration: 0.25 } }}
+            in={step === Step.EXIT}
+          >
             {step === Step.EXIT && <ExitStep />}
           </Fade>
         </Flex>

--- a/testnet.renegade.fi/contexts/Exchange/exchange-context.tsx
+++ b/testnet.renegade.fi/contexts/Exchange/exchange-context.tsx
@@ -112,7 +112,7 @@ function ExchangeProvider({ children }: ExchangeProviderProps) {
           exchange: Exchange,
           baseTicker: string,
           quoteTicker: string
-        ): PriceReport => {
+        ): PriceReport | undefined => {
           const key = getKey(exchange, baseTicker, quoteTicker)
           return priceReport[key]
         },

--- a/testnet.renegade.fi/contexts/Exchange/types.ts
+++ b/testnet.renegade.fi/contexts/Exchange/types.ts
@@ -7,5 +7,9 @@ export interface ExchangeContextValue {
     quote: string,
     decimals?: number
   ) => Promise<CallbackId | undefined>
-  getPriceData: (exchange: Exchange, base: string, quote: string) => PriceReport
+  getPriceData: (
+    exchange: Exchange,
+    base: string,
+    quote: string
+  ) => PriceReport | undefined
 }

--- a/testnet.renegade.fi/contexts/Renegade/renegade-context.tsx
+++ b/testnet.renegade.fi/contexts/Renegade/renegade-context.tsx
@@ -161,14 +161,6 @@ function RenegadeProvider({ children }: RenegadeProviderProps) {
     }
   }, [])
 
-  React.useEffect(() => {
-    if (taskState === TaskState.Completed) {
-      setTaskId(undefined)
-      setTaskType(undefined)
-      setTaskState(undefined)
-    }
-  }, [taskState])
-
   const refreshAccount = (accountId?: AccountId) => {
     if (!accountId) return
     setBalances(renegade.getBalances(accountId))

--- a/testnet.renegade.fi/lib/utils.ts
+++ b/testnet.renegade.fi/lib/utils.ts
@@ -29,12 +29,12 @@ export async function getTokenBannerData(renegade: Renegade) {
 export function findBalanceByTicker(
   balances: Record<BalanceId, Balance>,
   ticker: string
-): Balance | undefined {
+) {
   const addressToFind = new Token({ ticker }).address
-  const foundBalance = Object.entries(balances)
-    .map(([, balance]) => balance)
-    .find((balance) => balance.mint.address === addressToFind)
-
-  // TODO: Return 0 balance instead of undefined
+  const foundBalance =
+    Object.entries(balances)
+      .map(([, balance]) => balance)
+      .find((balance) => balance.mint.address === addressToFind) ??
+    new Balance({ mint: new Token({ ticker }), amount: BigInt(0) })
   return foundBalance
 }


### PR DESCRIPTION
- Task status is now displayed on the same level as the blocking modal.
- A new modal has been added for creating a new wallet.
- Test funds are now 10 WETH or 10000 USDC
- When receiving WETH, it will default to selling WETH, and this behavior applies to other tickers as well.
- The fade effect on order information has been made softer for a smoother transition.
- Task states will now clear right after they finish, with TaskStatus lingering briefly before fading out.