### PR TITLE
testnet: Improve internal match flow

### DIFF
--- a/testnet.renegade.fi/components/panels/orders-panel.tsx
+++ b/testnet.renegade.fi/components/panels/orders-panel.tsx
@@ -270,7 +270,9 @@ function OrderBookPanel() {
                   KATANA_ADDRESS_TO_TICKER[
                     "0x" + orders[counterpartyOrder.id].baseToken.address
                   ]
-                } with ${
+                } ${
+                  orders[counterpartyOrder.id].side === "buy" ? "with" : "for"
+                } ${
                   KATANA_ADDRESS_TO_TICKER[
                     "0x" + orders[counterpartyOrder.id].quoteToken.address
                   ]

--- a/testnet.renegade.fi/components/panels/wallets-panel.tsx
+++ b/testnet.renegade.fi/components/panels/wallets-panel.tsx
@@ -2,15 +2,10 @@
 
 import React from "react"
 import { useRenegade } from "@/contexts/Renegade/renegade-context"
-import { TaskType, ViewEnum } from "@/contexts/Renegade/types"
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  LockIcon,
-  UnlockIcon,
-} from "@chakra-ui/icons"
+import { ViewEnum } from "@/contexts/Renegade/types"
+import { ArrowDownIcon, LockIcon, UnlockIcon } from "@chakra-ui/icons"
 import { Box, Button, Flex, Image, Text, useDisclosure } from "@chakra-ui/react"
-import { Balance, Exchange, Token } from "@renegade-fi/renegade-js"
+import { Balance, Exchange } from "@renegade-fi/renegade-js"
 import { useModal as useModalConnectKit } from "connectkit"
 import {
   useAccount as useAccountWagmi,
@@ -39,7 +34,6 @@ interface TokenBalanceProps {
   amount?: bigint
 }
 function TokenBalance(props: TokenBalanceProps) {
-  const { accountId, setTask } = useRenegade()
   const [logoUrl, setLogoUrl] = React.useState("")
   const ticker =
     getNetwork() === "katana"
@@ -102,7 +96,7 @@ function TokenBalance(props: TokenBalanceProps) {
           />
         </Box>
       </Flex>
-      <ArrowDownIcon
+      {/* <ArrowDownIcon
         width="calc(0.5 * var(--banner-height))"
         height="calc(0.5 * var(--banner-height))"
         borderRadius="100px"
@@ -141,13 +135,13 @@ function TokenBalance(props: TokenBalanceProps) {
               .then(([taskId]) => setTask(taskId, TaskType.Withdrawal))
           }
         }}
-      />
+      /> */}
     </Flex>
   )
 }
 
 function DepositWithdrawButtons() {
-  const { accountId, setTask, setView } = useRenegade()
+  const { setView } = useRenegade()
   return (
     <Flex
       flexDirection="row"
@@ -163,15 +157,19 @@ function DepositWithdrawButtons() {
         justifyContent="center"
         flexGrow="1"
         gap="5px"
+        color="white.60"
         borderColor="border"
         borderRight="var(--border)"
+        _hover={{
+          color: "white.90",
+        }}
         cursor="pointer"
         onClick={() => setView(ViewEnum.DEPOSIT)}
       >
         <Text>Deposit</Text>
         <ArrowDownIcon />
       </Flex>
-      <Flex
+      {/* <Flex
         alignItems="center"
         justifyContent="center"
         flexGrow="1"
@@ -190,7 +188,7 @@ function DepositWithdrawButtons() {
       >
         <Text>Withdraw</Text>
         <ArrowUpIcon />
-      </Flex>
+      </Flex> */}
     </Flex>
   )
 }

--- a/testnet.renegade.fi/components/steppers/deposit-stepper/steps/default-step.tsx
+++ b/testnet.renegade.fi/components/steppers/deposit-stepper/steps/default-step.tsx
@@ -16,12 +16,12 @@ import { Token } from "@renegade-fi/renegade-js"
 import { getNetwork } from "@/lib/utils"
 import { renegade } from "@/app/providers"
 
-import { useStepper } from "../deposit-stepper"
+import { ErrorType, useStepper } from "../deposit-stepper"
 
 export function DefaultStep() {
   const { baseTicker, baseTokenAmount } = useDeposit()
   const { setTask, accountId } = useRenegade()
-  const { onNext } = useStepper()
+  const { onNext, setError } = useStepper()
 
   const handleDeposit = async () => {
     if (!accountId) return
@@ -33,6 +33,14 @@ export function DefaultStep() {
       )
       .then(([taskId]) => setTask(taskId, TaskType.Deposit))
       .then(() => onNext())
+      .catch((e) => {
+        if (
+          e.message ===
+          "The relayer returned a non-200 response. wallet update already in progress"
+        ) {
+          setError(ErrorType.WALLET_LOCKED)
+        }
+      })
   }
 
   return (

--- a/testnet.renegade.fi/components/steppers/deposit-stepper/steps/error-step.tsx
+++ b/testnet.renegade.fi/components/steppers/deposit-stepper/steps/error-step.tsx
@@ -1,0 +1,58 @@
+import { Button, Flex, ModalBody, Text } from "@chakra-ui/react"
+
+import { ErrorType, useStepper } from "../deposit-stepper"
+
+export function ErrorStep() {
+  const { onClose, error } = useStepper()
+  const title = {
+    [ErrorType.WALLET_LOCKED]: "Wallet locked",
+    "": "",
+  }[error || ""]
+  const content = {
+    [ErrorType.WALLET_LOCKED]: "Please wait for the ongoing task to complete.",
+    "": "",
+  }[error || ""]
+
+  return (
+    <ModalBody>
+      <Flex
+        alignItems="center"
+        justifyContent="center"
+        flexDirection="column"
+        gap="12"
+        textAlign="center"
+      >
+        <Text
+          color="white.50"
+          fontFamily="Favorit Extended"
+          fontSize="1.3em"
+          fontWeight="200"
+        >
+          {title}
+        </Text>
+        <Text fontSize="0.9em">{content}</Text>
+        <Button
+          padding="20px"
+          color="white.80"
+          fontSize="1.2em"
+          fontWeight="200"
+          borderWidth="thin"
+          borderColor="white.40"
+          borderRadius="100px"
+          _hover={{
+            borderColor: "white.60",
+            color: "white",
+          }}
+          _focus={{
+            backgroundColor: "transparent",
+          }}
+          transition="0.15s"
+          backgroundColor="transparent"
+          onClick={onClose}
+        >
+          Close
+        </Button>
+      </Flex>
+    </ModalBody>
+  )
+}

--- a/testnet.renegade.fi/components/steppers/deposit-stepper/steps/exit-step.tsx
+++ b/testnet.renegade.fi/components/steppers/deposit-stepper/steps/exit-step.tsx
@@ -95,6 +95,7 @@ export function ExitStep() {
           transition="0.15s"
           backgroundColor="transparent"
           onClick={() => {
+            router.prefetch(`/${baseTicker}/USDC`)
             router.push(`/${baseTicker}/USDC`)
             setView(ViewEnum.TRADING)
             onClose()

--- a/testnet.renegade.fi/components/steppers/order-stepper/order-stepper.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/order-stepper.tsx
@@ -1,6 +1,8 @@
-import React, { createContext, useContext, useState } from "react"
+import React, { createContext, useContext, useEffect, useState } from "react"
 import { useRenegade } from "@/contexts/Renegade/renegade-context"
 import { Fade, Flex, Modal, ModalContent, ModalOverlay } from "@chakra-ui/react"
+
+import { ErrorStep } from "@/components/steppers/order-stepper/steps/error-step"
 
 import { ConfirmStep } from "./steps/confirm-step"
 import { ExitStep } from "./steps/exit-step"
@@ -41,6 +43,12 @@ const OrderStepperInner = () => {
           >
             {step === Step.EXIT && <ExitStep />}
           </Fade>
+          <Fade
+            transition={{ enter: { duration: 0.25 } }}
+            in={step === Step.ERROR}
+          >
+            {step === Step.ERROR && <ErrorStep />}
+          </Fade>
         </Flex>
       </ModalContent>
     </Modal>
@@ -55,17 +63,25 @@ export function OrderStepper({ onClose }: { onClose: () => void }) {
   )
 }
 
+export enum ErrorType {
+  ORDERBOOK_FULL = "ORDERBOOK_FULL",
+  WALLET_LOCKED = "WALLET_LOCKED",
+}
+
 export enum Step {
   DEFAULT,
   LOADING,
   EXIT,
+  ERROR,
 }
 
 interface StepperContextType {
+  error?: ErrorType
   midpoint: number
   onBack: () => void
   onClose: () => void
   onNext: () => void
+  setError: (error: ErrorType) => void
   setMidpoint: (midpoint: number) => void
   setStep: (step: Step) => void
   step: Step
@@ -76,6 +92,7 @@ const StepperContext = createContext<StepperContextType>({
   onBack: () => {},
   onClose: () => {},
   onNext: () => {},
+  setError: () => {},
   setMidpoint: () => {},
   setStep: () => {},
   step: Step.DEFAULT,
@@ -93,6 +110,7 @@ const StepperProvider = ({
   const [step, setStep] = useState(Step.DEFAULT)
   const [midpoint, setMidpoint] = useState(0)
   const { setTask } = useRenegade()
+  const [error, setError] = useState<ErrorType>()
 
   const handleNext = () => {
     setStep(step + 1)
@@ -108,13 +126,19 @@ const StepperProvider = ({
     onClose()
   }
 
+  useEffect(() => {
+    if (error) setStep(Step.ERROR)
+  }, [error])
+
   return (
     <StepperContext.Provider
       value={{
+        error,
         midpoint,
         onBack: handleBack,
         onClose: handleClose,
         onNext: handleNext,
+        setError,
         setMidpoint,
         setStep,
         step,

--- a/testnet.renegade.fi/components/steppers/order-stepper/steps/confirm-step.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/steps/confirm-step.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useExchange } from "@/contexts/Exchange/exchange-context"
 import { useOrder } from "@/contexts/Order/order-context"
 import { ArrowForwardIcon } from "@chakra-ui/icons"
@@ -29,6 +29,13 @@ export function ConfirmStep() {
     if (!priceReport || currentPriceReport?.midpointPrice) return
     setCurrentPriceReport(priceReport)
   }, [currentPriceReport?.midpointPrice, priceReport])
+
+  const limit = useMemo(() => {
+    if (!currentPriceReport || !currentPriceReport.midpointPrice) return 0
+    return direction === "buy"
+      ? currentPriceReport.midpointPrice * 1.2
+      : currentPriceReport.midpointPrice * 0.8
+  }, [currentPriceReport, direction])
 
   return (
     <>
@@ -73,9 +80,7 @@ export function ConfirmStep() {
               <Text color="white.50">
                 {direction === "buy" ? "Pay at most" : "Receive at least"}
               </Text>
-              <Text>
-                {currentPriceReport?.midpointPrice?.toFixed(2)}&nbsp;USDC
-              </Text>
+              <Text>{limit.toFixed(2)}&nbsp;USDC</Text>
             </Flex>
           </Flex>
         </Flex>

--- a/testnet.renegade.fi/components/steppers/order-stepper/steps/error-step.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/steps/error-step.tsx
@@ -1,0 +1,61 @@
+import { Button, Flex, ModalBody, Text } from "@chakra-ui/react"
+
+import { ErrorType, useStepper } from "../order-stepper"
+
+export function ErrorStep() {
+  const { onClose, error } = useStepper()
+  const title = {
+    [ErrorType.ORDERBOOK_FULL]: "Orderbook full",
+    [ErrorType.WALLET_LOCKED]: "Wallet locked",
+    "": "",
+  }[error || ""]
+  const content = {
+    [ErrorType.ORDERBOOK_FULL]:
+      "You can only have 5 orders in the orderbook at a time. Please cancel an existing order to make room for this one.",
+    [ErrorType.WALLET_LOCKED]: "Please wait for the ongoing task to complete.",
+    "": "",
+  }[error || ""]
+
+  return (
+    <ModalBody>
+      <Flex
+        alignItems="center"
+        justifyContent="center"
+        flexDirection="column"
+        gap="12"
+        textAlign="center"
+      >
+        <Text
+          color="white.50"
+          fontFamily="Favorit Extended"
+          fontSize="1.3em"
+          fontWeight="200"
+        >
+          {title}
+        </Text>
+        <Text fontSize="0.9em">{content}</Text>
+        <Button
+          padding="20px"
+          color="white.80"
+          fontSize="1.2em"
+          fontWeight="200"
+          borderWidth="thin"
+          borderColor="white.40"
+          borderRadius="100px"
+          _hover={{
+            borderColor: "white.60",
+            color: "white",
+          }}
+          _focus={{
+            backgroundColor: "transparent",
+          }}
+          transition="0.15s"
+          backgroundColor="transparent"
+          onClick={onClose}
+        >
+          Close
+        </Button>
+      </Flex>
+    </ModalBody>
+  )
+}

--- a/testnet.renegade.fi/components/steppers/order-stepper/steps/exit-step.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/steps/exit-step.tsx
@@ -81,7 +81,7 @@ export function ExitStep() {
               fontFamily="Favorit"
             >
               <Text color="white.50">
-                {direction === "buy" ? "Paid at most" : "Received at least"}
+                {direction === "buy" ? "Pay at most" : "Receive at least"}
               </Text>
               <Text variant={isHovered ? undefined : "blurred"}>
                 {midpoint.toFixed(2)}&nbsp;USDC

--- a/testnet.renegade.fi/components/steppers/order-stepper/steps/loading-step.tsx
+++ b/testnet.renegade.fi/components/steppers/order-stepper/steps/loading-step.tsx
@@ -9,10 +9,7 @@ export function LoadingStep() {
   const { onNext } = useStepper()
   const { taskState, taskType } = useRenegade()
   useEffect(() => {
-    if (
-      taskType === TaskType.PlaceOrder &&
-      taskState === TaskState.UpdatingValidityProofs
-    ) {
+    if (taskType === TaskType.PlaceOrder && taskState === TaskState.Completed) {
       onNext()
     }
   }, [onNext, taskState, taskType])

--- a/testnet.renegade.fi/contexts/Order/order-context.tsx
+++ b/testnet.renegade.fi/contexts/Order/order-context.tsx
@@ -175,9 +175,13 @@ function OrderProvider({ children }: OrderProviderProps) {
       type: "midpoint",
       amount: BigInt(baseTokenAmount),
     })
-    renegade.task
-      .placeOrder(accountId, order)
+    return renegade.task
+      .modifyOrPlaceOrder(accountId, order)
       .then(([taskId]) => setTask(taskId, TaskType.PlaceOrder))
+      .catch((e) => {
+        console.log("🚀 ~ handlePlaceOrder ~ e:", e.message)
+        throw new Error(e)
+      })
   }, [accountId, baseTicker, baseTokenAmount, direction, quoteTicker, setTask])
 
   const handleSetDirection = useCallback((direction: Direction) => {

--- a/testnet.renegade.fi/hooks/use-global-orders.ts
+++ b/testnet.renegade.fi/hooks/use-global-orders.ts
@@ -27,7 +27,7 @@ export const useGlobalOrders = () => {
   return orders
 }
 
-interface GlobalOrder {
+export interface GlobalOrder {
   id: OrderId
   public_share_nullifier: Array<any>
   local: boolean

--- a/testnet.renegade.fi/hooks/use-price.ts
+++ b/testnet.renegade.fi/hooks/use-price.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react"
+import { ExchangeHealthState, Token } from "@renegade-fi/renegade-js"
+
+import { renegade } from "@/app/providers"
+
+export const usePrice = (base: string) => {
+  const [price, setPrice] = useState<ExchangeHealthState>({})
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const fetchedPrice = await renegade.queryExchangeHealthStates(
+        new Token({ ticker: base }),
+        new Token({ ticker: "USDC" })
+      )
+      setPrice(fetchedPrice)
+    }, 1000)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [base])
+
+  return price
+}


### PR DESCRIPTION
Integrate relayer side changes of locking wallets while tasks are being executed on them. Also shows errors if the user tries to make more than 5 active orders in their orderbook at one time.

Note: deployments will fail until JS SDK v0.3.9 is pushed