### PR TITLE
trade: Use Token object abstraction

### DIFF
--- a/trade.renegade.fi/app/(desktop)/[base]/[quote]/page.tsx
+++ b/trade.renegade.fi/app/(desktop)/[base]/[quote]/page.tsx
@@ -1,9 +1,10 @@
 import Image from "next/image"
 import { env } from "@/env.mjs"
 import backgroundPattern from "@/icons/background_pattern.png"
-import { Renegade, Token } from "@renegade-fi/renegade-js"
+import { Renegade } from "@renegade-fi/renegade-js"
 
 import { DISPLAYED_TICKERS } from "@/lib/tokens"
+import { getToken } from "@/lib/utils"
 import { MedianBanner } from "@/components/banners/median-banner"
 import { RelayerStatusData } from "@/components/banners/relayer-status-data"
 import { OrdersAndCounterpartiesPanel } from "@/components/panels/orders-panel"
@@ -35,9 +36,10 @@ export default async function Page({
 }: {
   params: { base: string; quote: string }
 }) {
+  // TODO: Network is hardcoded until PriceReporter token addresses are standardized
   const report = await renegade.queryExchangeHealthStates(
-    new Token({ ticker: base }),
-    new Token({ ticker: quote })
+    getToken({ input: base, network: "goerli" }),
+    getToken({ input: quote, network: "goerli" })
   )
   return (
     <div

--- a/trade.renegade.fi/components/live-price.tsx
+++ b/trade.renegade.fi/components/live-price.tsx
@@ -47,7 +47,7 @@ export const LivePrices = ({
     })
   }, [priceReport])
 
-  const baseDefaultDecimals = TICKER_TO_DEFAULT_DECIMALS[baseTicker]
+  const baseDefaultDecimals = TICKER_TO_DEFAULT_DECIMALS[baseTicker] || 0
   const trailingDecimals = useMemo(() => {
     if (quoteTicker !== "USDC") {
       return 2

--- a/trade.renegade.fi/components/modals/token-select-modal.tsx
+++ b/trade.renegade.fi/components/modals/token-select-modal.tsx
@@ -18,13 +18,8 @@ import {
 } from "@chakra-ui/react"
 import SimpleBar from "simplebar-react"
 
-import {
-  DISPLAYED_TICKERS,
-  KATANA_TICKER_TO_ADDR,
-  TICKER_TO_ADDR,
-  TICKER_TO_NAME,
-} from "@/lib/tokens"
-import { getNetwork } from "@/lib/utils"
+import { DISPLAYED_TICKERS, TICKER_TO_NAME } from "@/lib/tokens"
+import { getToken } from "@/lib/utils"
 import { useBalance } from "@/hooks/use-balance"
 import { useDebounce } from "@/hooks/use-debounce"
 
@@ -103,12 +98,9 @@ export function TokenSelectModal({
             {filteredTickers
               .filter(([base]) => (isTrading ? base !== "USDC" : true))
               .map(([ticker]) => {
-                const tickerAddress =
-                  getNetwork() === "katana"
-                    ? KATANA_TICKER_TO_ADDR[ticker]
-                    : TICKER_TO_ADDR[ticker]
+                const addr = getToken({ ticker }).address
                 const matchingBalance = Object.values(balances).find(
-                  (balance) => `0x${balance.mint.address}` === tickerAddress
+                  ({ mint: { address } }) => address === addr
                 )
                 const balanceAmount = matchingBalance
                   ? matchingBalance.amount.toString()

--- a/trade.renegade.fi/components/panels/orders-panel.tsx
+++ b/trade.renegade.fi/components/panels/orders-panel.tsx
@@ -12,8 +12,12 @@ import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 import SimpleBar from "simplebar-react"
 
-import { ADDR_TO_TICKER, KATANA_ADDRESS_TO_TICKER } from "@/lib/tokens"
-import { getNetwork, safeLocalStorageGetItem } from "@/lib/utils"
+import { KATANA_ADDRESS_TO_TICKER } from "@/lib/tokens"
+import {
+  getTickerFromToken,
+  getToken,
+  safeLocalStorageGetItem,
+} from "@/lib/utils"
 import { useGlobalOrders } from "@/hooks/use-global-orders"
 import { useOrders } from "@/hooks/use-order"
 import { Panel, expandedPanelWidth } from "@/components/panels/panels"
@@ -43,15 +47,8 @@ function SingleOrder({
   const { tokenIcons } = useApp()
   const { accountId, setTask } = useRenegade()
 
-  const base =
-    getNetwork() === "katana"
-      ? KATANA_ADDRESS_TO_TICKER["0x" + baseAddr]
-      : ADDR_TO_TICKER["0x" + baseAddr]
-
-  const quote =
-    getNetwork() === "katana"
-      ? KATANA_ADDRESS_TO_TICKER["0x" + quoteAddr]
-      : ADDR_TO_TICKER["0x" + quoteAddr]
+  const base = getTickerFromToken(getToken({ address: baseAddr }))
+  const quote = getTickerFromToken(getToken({ address: quoteAddr }))
 
   const handleCancel = () => {
     if (!accountId) return

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -7,17 +7,12 @@ import { ViewEnum, useApp } from "@/contexts/App/app-context"
 import { useRenegade } from "@/contexts/Renegade/renegade-context"
 import { ArrowDownIcon, LockIcon, UnlockIcon } from "@chakra-ui/icons"
 import { Box, Button, Flex, HStack, Spacer, Text } from "@chakra-ui/react"
-import { Token } from "@renegade-fi/renegade-js"
 import { useModal as useModalConnectKit } from "connectkit"
 import SimpleBar from "simplebar-react"
 import { useAccount as useAccountWagmi } from "wagmi"
 
-import {
-  ADDR_TO_TICKER,
-  DISPLAYED_TICKERS,
-  KATANA_ADDRESS_TO_TICKER,
-} from "@/lib/tokens"
-import { findBalanceByTicker, getNetwork } from "@/lib/utils"
+import { DISPLAYED_TICKERS } from "@/lib/tokens"
+import { findBalanceByTicker, getTickerFromToken, getToken } from "@/lib/utils"
 import { useBalance } from "@/hooks/use-balance"
 import { useUSDPrice } from "@/hooks/use-usd-price"
 import { Panel, expandedPanelWidth } from "@/components/panels/panels"
@@ -35,10 +30,7 @@ function TokenBalance(props: TokenBalanceProps) {
   const { setView } = useApp()
   const router = useRouter()
 
-  const ticker =
-    getNetwork() === "katana"
-      ? KATANA_ADDRESS_TO_TICKER[props.tokenAddr]
-      : ADDR_TO_TICKER[props.tokenAddr]
+  const ticker = getTickerFromToken(getToken({ address: props.tokenAddr }))
   const usdPrice = useUSDPrice(ticker, Number(props.amount))
 
   const isZero = props.amount === BigInt(0)
@@ -155,7 +147,7 @@ function RenegadeWalletPanel(props: RenegadeWalletPanelProps) {
     const result: [string, bigint][] = []
     for (const [base] of DISPLAYED_TICKERS) {
       const bal = findBalanceByTicker(balances, base)
-      const address = new Token({ ticker: base, network: getNetwork() }).address
+      const address = getToken({ ticker: base }).address
       result.push([address, bal.amount])
     }
     return result

--- a/trade.renegade.fi/components/steppers/deposit-stepper/steps/default-step.tsx
+++ b/trade.renegade.fi/components/steppers/deposit-stepper/steps/default-step.tsx
@@ -11,9 +11,8 @@ import {
   ModalFooter,
   Text,
 } from "@chakra-ui/react"
-import { Token } from "@renegade-fi/renegade-js"
 
-import { getNetwork } from "@/lib/utils"
+import { getToken } from "@/lib/utils"
 import { renegade } from "@/app/providers"
 
 import { ErrorType, useStepper } from "../deposit-stepper"
@@ -28,7 +27,7 @@ export function DefaultStep() {
     renegade.task
       .deposit(
         accountId,
-        new Token({ ticker: baseTicker, network: getNetwork() }),
+        getToken({ ticker: baseTicker }),
         BigInt(baseTokenAmount)
       )
       .then(([taskId]) => setTask(taskId, TaskType.Deposit))

--- a/trade.renegade.fi/components/steppers/order-stepper/steps/confirm-step.tsx
+++ b/trade.renegade.fi/components/steppers/order-stepper/steps/confirm-step.tsx
@@ -14,20 +14,10 @@ import {
   ModalFooter,
   Text,
 } from "@chakra-ui/react"
-import {
-  Exchange,
-  Order,
-  OrderId,
-  PriceReport,
-  Token,
-} from "@renegade-fi/renegade-js"
+import { Exchange, Order, OrderId, PriceReport } from "@renegade-fi/renegade-js"
 import { v4 as uuidv4 } from "uuid"
 
-import {
-  getNetwork,
-  safeLocalStorageGetItem,
-  safeLocalStorageSetItem,
-} from "@/lib/utils"
+import { safeLocalStorageGetItem, safeLocalStorageSetItem } from "@/lib/utils"
 import { renegade } from "@/app/providers"
 
 import { ErrorType, useStepper } from "../order-stepper"
@@ -45,9 +35,11 @@ export function ConfirmStep() {
   const { onClose, setMidpoint, setError } = useStepper()
   const { getPriceData } = useExchange()
   const {
+    base,
     baseTicker,
     baseTokenAmount,
     direction,
+    quote,
     quoteTicker,
     setBaseTokenAmount,
   } = useOrder()
@@ -72,8 +64,8 @@ export function ConfirmStep() {
     const id = uuidv4() as OrderId
     const order = new Order({
       id,
-      baseToken: new Token({ ticker: baseTicker, network: getNetwork() }),
-      quoteToken: new Token({ ticker: quoteTicker, network: getNetwork() }),
+      baseToken: base,
+      quoteToken: quote,
       side: direction,
       type: "midpoint",
       amount: BigInt(baseTokenAmount),

--- a/trade.renegade.fi/components/steppers/testnet-stepper/steps/default-step.tsx
+++ b/trade.renegade.fi/components/steppers/testnet-stepper/steps/default-step.tsx
@@ -8,10 +8,9 @@ import {
   ModalFooter,
   Text,
 } from "@chakra-ui/react"
-import { Token } from "@renegade-fi/renegade-js"
 import { Repeat2 } from "lucide-react"
 
-import { getNetwork } from "@/lib/utils"
+import { getToken } from "@/lib/utils"
 import { renegade } from "@/app/providers"
 
 import { useStepper } from "../testnet-stepper"
@@ -25,11 +24,7 @@ export function DefaultStep() {
   const handleDeposit = async () => {
     if (!accountId) return
     renegade.task
-      .deposit(
-        accountId,
-        new Token({ ticker, network: getNetwork() }),
-        BigInt(amount)
-      )
+      .deposit(accountId, getToken({ ticker: ticker }), BigInt(amount))
       .then(([taskId]) => setTask(taskId, TaskType.Deposit))
       .then(() => onNext())
   }

--- a/trade.renegade.fi/contexts/Deposit/deposit-context.tsx
+++ b/trade.renegade.fi/contexts/Deposit/deposit-context.tsx
@@ -2,8 +2,12 @@
 
 import { PropsWithChildren, createContext, useContext, useState } from "react"
 import { useParams, useRouter } from "next/navigation"
+import { Token } from "@renegade-fi/renegade-js"
+
+import { getTickerFromToken, getToken } from "@/lib/utils"
 
 export interface DepositContextValue {
+  base: Token
   baseTicker: string
   baseTokenAmount: number
   setBaseTicker: (ticker: string) => void
@@ -17,7 +21,8 @@ const DepositStateContext = createContext<DepositContextValue | undefined>(
 function DepositProvider({ children }: PropsWithChildren) {
   const params = useParams()
   const router = useRouter()
-  const baseTicker = params.base?.toString()
+  const base = params.base?.toString()
+  const baseToken = getToken({ input: base })
   const handleSetBaseToken = (token: string) => {
     router.push(`/${token}`)
   }
@@ -26,7 +31,8 @@ function DepositProvider({ children }: PropsWithChildren) {
   return (
     <DepositStateContext.Provider
       value={{
-        baseTicker,
+        base: baseToken,
+        baseTicker: getTickerFromToken(baseToken),
         baseTokenAmount,
         setBaseTicker: handleSetBaseToken,
         setBaseTokenAmount,

--- a/trade.renegade.fi/contexts/Exchange/exchange-context.tsx
+++ b/trade.renegade.fi/contexts/Exchange/exchange-context.tsx
@@ -7,13 +7,9 @@ import {
   useRef,
   useState,
 } from "react"
-import {
-  CallbackId,
-  Exchange,
-  PriceReport,
-  Token,
-} from "@renegade-fi/renegade-js"
+import { CallbackId, Exchange, PriceReport } from "@renegade-fi/renegade-js"
 
+import { getToken } from "@/lib/utils"
 import { renegade } from "@/app/providers"
 
 import { ExchangeContextValue } from "./types"
@@ -70,8 +66,8 @@ function ExchangeProvider({ children }: PropsWithChildren) {
             })
           },
           exchange,
-          new Token({ ticker: base }),
-          new Token({ ticker: quote })
+          getToken({ ticker: base, network: "goerli" }),
+          getToken({ ticker: quote, network: "goerli" })
         )
         .then((callbackId) => {
           if (callbackId) {

--- a/trade.renegade.fi/contexts/Order/types.ts
+++ b/trade.renegade.fi/contexts/Order/types.ts
@@ -1,12 +1,16 @@
+import { Token } from "@renegade-fi/renegade-js"
+
 export enum Direction {
   BUY = "buy",
   SELL = "sell",
 }
 
 export interface OrderContextValue {
+  base: Token
   baseTicker: string
   baseTokenAmount: number
   direction: Direction
+  quote: Token
   quoteTicker: string
   setBaseToken: (token: string) => void
   setBaseTokenAmount: (amount: number) => void

--- a/trade.renegade.fi/lib/utils.ts
+++ b/trade.renegade.fi/lib/utils.ts
@@ -1,7 +1,11 @@
 import { env } from "@/env.mjs"
 import { Balance, BalanceId, Renegade, Token } from "@renegade-fi/renegade-js"
 
-import { DISPLAYED_TICKERS } from "@/lib/tokens"
+import {
+  ADDR_TO_TICKER,
+  DISPLAYED_TICKERS,
+  KATANA_ADDRESS_TO_TICKER,
+} from "@/lib/tokens"
 
 export function safeLocalStorageGetItem(key: string): string | null {
   if (typeof window !== "undefined") {
@@ -20,8 +24,8 @@ export async function getTokenBannerData(renegade: Renegade) {
   return await Promise.all(
     DISPLAYED_TICKERS.map(([baseTicker, quoteTicker]) =>
       renegade.queryExchangeHealthStates(
-        new Token({ ticker: baseTicker }),
-        new Token({ ticker: quoteTicker })
+        getToken({ ticker: baseTicker, network: "goerli" }),
+        getToken({ ticker: quoteTicker, network: "goerli" })
       )
     )
   ).then((res) => res.map((e) => e.Median))
@@ -31,13 +35,13 @@ export function findBalanceByTicker(
   balances: Record<BalanceId, Balance>,
   ticker: string
 ) {
-  const addressToFind = new Token({ ticker, network: getNetwork() }).address
+  const addressToFind = getToken({ ticker, network: getNetwork() }).address
   const foundBalance =
     Object.entries(balances)
       .map(([, balance]) => balance)
       .find((balance) => balance.mint.address === addressToFind) ??
     new Balance({
-      mint: new Token({ ticker, network: getNetwork() }),
+      mint: getToken({ ticker, network: getNetwork() }),
       amount: BigInt(0),
     })
   return foundBalance
@@ -60,4 +64,34 @@ export function getNetwork() {
     }
   }
   return undefined
+}
+
+export function getToken(token: {
+  address?: string
+  ticker?: string
+  input?: string
+  network?: string
+}) {
+  const network = token.network ?? getNetwork()
+  if (token.input && token.input.length > 6) {
+    return new Token({ address: token.input, network })
+  } else if (token.input && token.input.length <= 6) {
+    return new Token({ ticker: token.input, network })
+  } else if (token.address) {
+    return new Token({ address: token.address, network })
+  } else {
+    return new Token({ ticker: token.ticker, network })
+  }
+}
+
+export function getTickerFromToken(token: Token) {
+  try {
+    if (getNetwork() === "katana") {
+      return KATANA_ADDRESS_TO_TICKER[`0x${token.address}`]
+    } else {
+      return ADDR_TO_TICKER[`0x${token.address}`]
+    }
+  } catch (error) {
+    throw new Error(`Could not get ticker from token: ${token}`)
+  }
 }


### PR DESCRIPTION
This PR adds a layer of abstraction by using the Token object everywhere possible, so that future changes regarding tokens can be consistently applied to the whole app. Main affected areas are when fetching a token from the URL parameters, and using addresses/tickers to interact with the Renegade API.