### PR TITLE
trade: UX Nits

### DIFF
--- a/trade.renegade.fi/components/banner-separator.tsx
+++ b/trade.renegade.fi/components/banner-separator.tsx
@@ -5,7 +5,7 @@ interface BannerSeparatorProps {
 }
 export function BannerSeparator(props: BannerSeparatorProps) {
   return (
-    <Center flexGrow={props.flexGrow} height="100%">
+    <Center flexGrow={props.flexGrow || 4} height="100%">
       <Box width="4px" height="4px" background="white.80" borderRadius="2px" />
     </Center>
   )

--- a/trade.renegade.fi/components/banners/median-banner.tsx
+++ b/trade.renegade.fi/components/banners/median-banner.tsx
@@ -187,43 +187,6 @@ function ExchangeConnectionTriple(props: ExchangeConnectionTripleProps) {
   )
 }
 
-interface MedianTripleProps {
-  activeBaseTicker: string
-  activeQuoteTicker: string
-  initialPrice?: number
-  isMobile?: boolean
-}
-function MedianTriple(props: MedianTripleProps) {
-  return (
-    <Flex
-      alignItems="center"
-      justifyContent="center"
-      flexDirection={props.isMobile ? "column" : "row"}
-      width={props.isMobile ? "100%" : "24%"}
-      minWidth={props.isMobile ? undefined : "400px"}
-      height={props.isMobile ? "40%" : "100%"}
-      paddingTop={props.isMobile ? "10px" : undefined}
-    >
-      <Spacer flexGrow="3" />
-      <Text
-        whiteSpace="nowrap"
-        variant={props.isMobile ? "rotate-right" : undefined}
-      >
-        NBBO Feed
-      </Text>
-      <BannerSeparator flexGrow={4} />
-      <ExchangeConnectionTriple
-        activeBaseTicker={props.activeBaseTicker}
-        activeQuoteTicker={props.activeQuoteTicker}
-        exchange={Exchange.Binance}
-        isMobile={props.isMobile}
-        initialPrice={props.initialPrice}
-      />
-      <BannerSeparator flexGrow={4} />
-    </Flex>
-  )
-}
-
 interface ExchangeConnectionsBannerProps {
   activeBaseTicker: string
   activeQuoteTicker: string
@@ -434,16 +397,20 @@ export class MedianBanner extends React.Component<
         userSelect="none"
         spacing="0px"
       >
-        <MedianTriple
-          activeBaseTicker={this.props.activeBaseTicker}
-          activeQuoteTicker={this.props.activeQuoteTicker}
-          isMobile={this.props.isMobile}
-          initialPrice={this.props.report?.[Exchange.Binance]}
-        />
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          width="13%"
+          minWidth="125px"
+          height="100%"
+        >
+          BBO Feeds
+        </Flex>
+        <BannerSeparator flexGrow={1} />
         <Flex
           position="relative"
           flexDirection={this.props.isMobile ? "column" : "row"}
-          width={this.props.isMobile ? undefined : "76%"}
+          width={this.props.isMobile ? undefined : "87%"}
           height={this.props.isMobile ? "60%" : undefined}
         >
           <Box
@@ -490,14 +457,15 @@ export class MedianBanner extends React.Component<
               minWidth={this.props.isMobile ? undefined : "1200px"}
               minHeight={this.props.isMobile ? "310vw" : "var(--banner-height)"}
             >
-              {/* <ExchangeConnectionTriple
+              <Spacer flexGrow="2" />
+              <ExchangeConnectionTriple
                 activeBaseTicker={this.props.activeBaseTicker}
                 activeQuoteTicker={this.props.activeQuoteTicker}
                 exchange={Exchange.Binance}
-                // priceReport={this.props.report.Binance}
+                initialPrice={this.props.report?.[Exchange.Binance]}
                 isMobile={this.props.isMobile}
               />
-              <BannerSeparator /> */}
+              <BannerSeparator />
               <ExchangeConnectionTriple
                 activeBaseTicker={this.props.activeBaseTicker}
                 activeQuoteTicker={this.props.activeQuoteTicker}
@@ -521,15 +489,7 @@ export class MedianBanner extends React.Component<
                 initialPrice={this.props.report?.[Exchange.Okx]}
                 isMobile={this.props.isMobile}
               />
-              {/* <BannerSeparator /> */}
-              {/* <ExchangeConnectionTriple
-                activeBaseTicker={this.props.activeBaseTicker}
-                activeQuoteTicker={this.props.activeQuoteTicker}
-                exchange={Exchange.Uniswapv3}
-                // priceReport={this.props.report.UniswapV3}
-                isMobile={this.props.isMobile}
-              /> */}
-              <Spacer flexGrow="3" />
+              <Spacer flexGrow="2" />
             </Flex>
           </Box>
         </Flex>

--- a/trade.renegade.fi/components/banners/median-banner.tsx
+++ b/trade.renegade.fi/components/banners/median-banner.tsx
@@ -70,7 +70,7 @@ function ExchangeConnectionTriple(props: ExchangeConnectionTripleProps) {
   }
   if (renamedQuoteTicker === "USDC") {
     renamedQuoteTicker = {
-      binance: "BUSD",
+      binance: "USDT",
       coinbase: "USD",
       kraken: "USD",
       okx: "USDT",
@@ -82,7 +82,7 @@ function ExchangeConnectionTriple(props: ExchangeConnectionTripleProps) {
     binance: `https://www.binance.com/en/trade/${renamedBaseTicker}_${renamedQuoteTicker}`,
     coinbase: `https://www.coinbase.com/advanced-trade/${renamedBaseTicker}-${renamedQuoteTicker}`,
     kraken: `https://pro.kraken.com/app/trade/${renamedBaseTicker}-${renamedQuoteTicker}`,
-    okx: `https://www.okx.com/trade-swap/${renamedBaseTicker}-${renamedQuoteTicker}-swap`,
+    okx: `https://www.okx.com/trade-spot/${renamedBaseTicker}-${renamedQuoteTicker}`,
     uniswapv3: `https://info.uniswap.org/#/tokens/${Token.findAddressByTicker(
       props.activeBaseTicker
     )}`,

--- a/trade.renegade.fi/components/banners/relayer-banner.tsx
+++ b/trade.renegade.fi/components/banners/relayer-banner.tsx
@@ -171,11 +171,11 @@ export class RelayerStatusBanner extends React.Component<
               height="var(--banner-height)"
             >
               <Spacer flexGrow="2" />
-              <Text>Liquidity</Text>
+              <Text>TVL</Text>
               <BannerSeparator flexGrow={1} />
-              <Text>420.00 {this.props.activeBaseTicker}</Text>
+              <Text>123.456 {this.props.activeBaseTicker}</Text>
               <BannerSeparator flexGrow={1} />
-              <Text>69,000.00 {this.props.activeQuoteTicker}</Text>
+              <Text>123456.78 {this.props.activeQuoteTicker}</Text>
               <BannerSeparator flexGrow={3} />
               <Text>Relayer</Text>
               <BannerSeparator flexGrow={1} />

--- a/trade.renegade.fi/components/banners/tokens-banner.tsx
+++ b/trade.renegade.fi/components/banners/tokens-banner.tsx
@@ -22,6 +22,9 @@ export function TokensBanner({ prices }: { prices: number[] }) {
       }}
     >
       {DISPLAYED_TICKERS.map(([baseTicker, quoteTicker], i) => {
+        if (["USDC", "USDT"].includes(baseTicker)) {
+          return null
+        }
         return (
           <Link
             href={`/${baseTicker}/${quoteTicker}`}

--- a/trade.renegade.fi/components/panels/orders-panel.tsx
+++ b/trade.renegade.fi/components/panels/orders-panel.tsx
@@ -364,7 +364,7 @@ function OrderBookPanel() {
 }
 
 function CounterpartiesPanel() {
-  const { counterparties } = useRenegade()
+  const globalOrders = useGlobalOrders()
   return (
     <Flex
       position="relative"
@@ -375,8 +375,8 @@ function CounterpartiesPanel() {
       borderColor="border"
       borderTop="var(--border)"
     >
-      <Text>Counterparties:&nbsp;</Text>
-      <Text>{Object.keys(counterparties).length + 1}</Text>
+      <Text>Active Orders:&nbsp;</Text>
+      <Text>{Object.keys(globalOrders).length || "..."}</Text>
     </Flex>
   )
 }

--- a/trade.renegade.fi/components/panels/panels.tsx
+++ b/trade.renegade.fi/components/panels/panels.tsx
@@ -107,10 +107,10 @@ interface PanelState {
 export class Panel extends React.Component<PanelProps, PanelState> {
   constructor(props: PanelProps) {
     super(props)
+    const isLockedStorage = localStorage.getItem(this.getLocalStorageKey())
     this.state = {
       isHovering: false,
-      isLocked:
-        localStorage.getItem(this.getLocalStorageKey()) === "true" || false,
+      isLocked: isLockedStorage === "true" || isLockedStorage === null,
       isOpenModalWhenLeft: false,
       isModalJustClosed: false,
     }


### PR DESCRIPTION
## Changes

1. Change "liquidity" to "TVL", since only the total pool sizes are knowable.
2. Adjust spacing on the median price reports banner.
3. Report the number of active orders (in the thousands), rather than the number of counterparty nodes (currently just one).
4. Remove USDC/USDT from the lower banner, since they're not clickable.
5. Update the external links to Binance and OKX.
6. Keep the panels locked on first load, since that UX primitive is not intuitive.
