### PR TITLE
trade: Add order history

### DIFF
--- a/trade.renegade.fi/components/place-order-button.tsx
+++ b/trade.renegade.fi/components/place-order-button.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import { usePrice } from "@/contexts/PriceContext/price-context"
-import { Direction, LocalOrder } from "@/lib/types"
-import { safeLocalStorageGetItem, safeLocalStorageSetItem } from "@/lib/utils"
+import { Direction } from "@/lib/types"
 import { ArrowForwardIcon } from "@chakra-ui/icons"
 import { Button, useDisclosure } from "@chakra-ui/react"
 import {
@@ -13,7 +12,6 @@ import {
   useBalances,
   useConfig,
   useStatus,
-  useWalletId,
 } from "@renegade-fi/react"
 import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
@@ -57,7 +55,6 @@ export function PlaceOrderButton({
   })
 
   const config = useConfig()
-  const walletId = useWalletId()
   const status = useStatus()
 
   const isConnected = status === "in relayer"
@@ -74,29 +71,9 @@ export function PlaceOrderButton({
     })
       .then(() => {
         toast.message(
-          `Started to place order to ${
+          `Creating order to ${
             direction === "buy" ? "Buy" : "Sell"
-          } ${baseTokenAmount} ${base} for ${quote}`,
-          {
-            description: "Check the history tab for the status of the task",
-          }
-        )
-        const old = safeLocalStorageGetItem(`order-details-${walletId}`)
-        const parseOld: LocalOrder[] = old ? JSON.parse(old) : []
-        const newO = [
-          ...parseOld,
-          {
-            id,
-            base: baseAddress,
-            quote: quoteAddress,
-            side: direction,
-            amount: baseTokenAmount,
-            timestamp: Date.now(),
-          },
-        ]
-        safeLocalStorageSetItem(
-          `order-details-${walletId}`,
-          JSON.stringify(newO)
+          } ${baseTokenAmount} ${base} for ${quote}`
         )
       })
       .catch((e) => {

--- a/trade.renegade.fi/contexts/App/app-context.tsx
+++ b/trade.renegade.fi/contexts/App/app-context.tsx
@@ -1,7 +1,18 @@
 "use client"
 
 import { fundList, fundWallet } from "@/lib/utils"
-import { connect, disconnect, useConfig } from "@renegade-fi/react"
+import {
+  OrderState,
+  Token,
+  UseOrderHistoryWebSocketReturnType,
+  connect,
+  disconnect,
+  formatAmount,
+  useConfig,
+  useOrderHistory,
+  useOrderHistoryWebSocket,
+  useOrders,
+} from "@renegade-fi/react"
 import {
   PropsWithChildren,
   createContext,
@@ -38,11 +49,73 @@ function AppProvider({
 }: PropsWithChildren & { tokenIcons?: Record<string, string> }) {
   const [view, setView] = useState<ViewEnum>(ViewEnum.TRADING)
 
+  // Order History Panel
+  const orderHistory = useOrderHistory()
+  const incomingOrder = useOrderHistoryWebSocket()
+  const orders = useOrders()
+  const orderMetadataRef = useRef<
+    Map<string, UseOrderHistoryWebSocketReturnType>
+  >(new Map())
+
+  // Hydrate initial filled states
+  useEffect(() => {
+    orderHistory.forEach((order) => {
+      if (orderMetadataRef.current.get(order.id)) return
+      orderMetadataRef.current.set(order.id, order)
+    })
+  }, [orderHistory])
+
+  useEffect(() => {
+    if (incomingOrder) {
+      const {
+        id,
+        filled,
+        state,
+        data: { base_mint, amount, side },
+      } = incomingOrder
+      const base = Token.findByAddress(base_mint)
+      const formattedAmount = formatAmount(amount, base)
+      const formattedFilled = formatAmount(filled, base)
+      const lastFilled = orderMetadataRef.current.get(id)?.filled || BigInt(0)
+
+      // Ignore duplicate events
+      if (orderMetadataRef.current.get(id)?.state === state) {
+        return
+      }
+
+      // TODO: Race condition if user orders gets update quicker than order history
+      if (state === OrderState.Created && !orders.find((o) => o.id === id)) {
+        toast.success(
+          `Order created: ${side} ${formattedAmount} ${base.ticker}`
+        )
+      } else if (state === OrderState.Filled) {
+        toast.success(
+          `Order completely filled: ${
+            side === "Buy" ? "Bought" : "Sold"
+          } ${formattedFilled} ${base.ticker}`
+        )
+      } else if (filled > lastFilled) {
+        const currentFill = filled - lastFilled
+        const formattedCurrentFill = formatAmount(currentFill, base)
+        toast.success(
+          `Order partially filled: ${
+            side === "Buy" ? "Bought" : "Sold"
+          } ${formattedCurrentFill} ${base.ticker}`
+        )
+      } else if (state === OrderState.Cancelled) {
+        toast.success(
+          `Order cancelled: ${side} ${formattedAmount} ${base.ticker}`
+        )
+      }
+
+      orderMetadataRef.current.set(id, incomingOrder)
+    }
+  }, [incomingOrder, orders])
+
   const config = useConfig()
 
+  // Browser Wallet
   const { address } = useAccount()
-  const [funded] = useLocalStorage(`funded_${address}`, false)
-
   const prevAddressRef = useRef<string>()
   useEffect(() => {
     if (
@@ -55,8 +128,9 @@ function AppProvider({
     prevAddressRef.current = address
   }, [address, config])
 
+  // Funding
+  const [funded] = useLocalStorage(`funded_${address}`, false)
   const { executeTaskWithToast } = useTaskCompletionToast()
-
   const handleSignin = async (seed: Hex) => {
     const res = await connect(config, { seed })
     if (res?.taskId) {

--- a/trade.renegade.fi/lib/utils.ts
+++ b/trade.renegade.fi/lib/utils.ts
@@ -1,4 +1,5 @@
 import { env } from "@/env.mjs"
+import { OrderState } from "@renegade-fi/react"
 import { Metadata } from "next"
 
 export function safeLocalStorageGetItem(key: string): string | null {
@@ -163,3 +164,18 @@ export const fundList: { ticker: string; amount: string }[] = [
     amount: "100",
   },
 ]
+
+export const getReadableState = (state: OrderState) => {
+  switch (state) {
+    case OrderState.Created:
+      return "Open"
+    case OrderState.Matching:
+      return "Open"
+    case OrderState.SettlingMatch:
+      return "Settling"
+    case OrderState.Filled:
+      return "Matched"
+    case OrderState.Cancelled:
+      return "Cancelled"
+  }
+}


### PR DESCRIPTION
This PR adds more visibility on the state of orders once they are placed. Now, toasts will appear notifying the user of partial and complete fills, in addition to order creation/cancellation.