### PR TITLE
trade: Prevent subscription to binance-DYDX-USDC

### DIFF
--- a/trade.renegade.fi/components/place-order-button.tsx
+++ b/trade.renegade.fi/components/place-order-button.tsx
@@ -129,13 +129,13 @@ export function PlaceOrderButton({
 
   const [price, setPrice] = useState(0)
   const { handleSubscribe, handleGetPrice } = usePrice()
-  const priceReport = handleGetPrice("binance", baseAddress, quoteAddress)
+  const priceReport = handleGetPrice("binance", baseAddress)
   useEffect(() => {
     if (!priceReport) return
     setPrice(priceReport)
   }, [priceReport])
   useEffect(() => {
-    handleSubscribe("binance", baseAddress, quoteAddress)
+    handleSubscribe("binance", baseAddress)
   }, [baseAddress, quoteAddress, handleSubscribe])
   let placeOrderButtonContent: string
   if (shouldUse) {

--- a/trade.renegade.fi/contexts/PriceContext/price-context.tsx
+++ b/trade.renegade.fi/contexts/PriceContext/price-context.tsx
@@ -69,6 +69,10 @@ export const PriceProvider = ({ children }: { children: React.ReactNode }) => {
   ) => {
     if (!priceReporter || invalid.includes(base)) return
 
+    // DYDX is not supported on Coinbase
+    if (exchange === "coinbase" && base === Token.findByTicker("DYDX").address)
+      return
+
     const topic = PRICE_REPORTER_TOPIC(exchange, base, quote)
     if (attempted[topic]) return
 


### PR DESCRIPTION
This PR prevents the frontend from subscribing to binance-{base}-USDC in favor of defaulting to the correct stable for Binance.