### PR TITLE
trade: execute pay fees task before withdrawal

### DIFF
--- a/trade.renegade.fi/app/(desktop)/withdraw-button.tsx
+++ b/trade.renegade.fi/app/(desktop)/withdraw-button.tsx
@@ -3,8 +3,10 @@ import { Button, useDisclosure } from "@chakra-ui/react"
 import {
   Token,
   parseAmount,
+  payFees,
   useBalances,
   useConfig,
+  useFees,
   useStatus,
   withdraw,
 } from "@renegade-fi/react"
@@ -54,8 +56,18 @@ export default function WithdrawButton({
   const config = useConfig()
   const { address } = useAccount()
 
+  const fees = useFees()
+
   const handleWithdraw = async () => {
     if (!address) return
+
+    if (fees.length > 0) {
+      const toastId = toast.loading("Paying fees before withdrawing")
+      await payFees(config)
+      toast.success("Fees successfully paid", { id: toastId })
+    }
+
+    // Withdraw
     const token = Token.findByTicker(baseTicker)
     const amount = parseAmount(baseTokenAmount, token)
     await withdraw(config, {

--- a/trade.renegade.fi/package.json
+++ b/trade.renegade.fi/package.json
@@ -22,7 +22,7 @@
     "@datadog/browser-rum": "^5.15.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@renegade-fi/react": "^0.0.3",
+    "@renegade-fi/react": "^0.0.5",
     "@t3-oss/env-nextjs": "^0.6.0",
     "@tanstack/react-query": "^5.24.1",
     "@vercel/analytics": "^1.2.2",

--- a/trade.renegade.fi/pnpm-lock.yaml
+++ b/trade.renegade.fi/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^11.11.0
     version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.2.77)(react@18.2.0)
   '@renegade-fi/react':
-    specifier: ^0.0.3
-    version: 0.0.3(@tanstack/react-query@5.29.2)(@types/react@18.2.77)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4)
+    specifier: ^0.0.5
+    version: 0.0.5(@tanstack/react-query@5.29.2)(@types/react@18.2.77)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4)
   '@t3-oss/env-nextjs':
     specifier: ^0.6.0
     version: 0.6.1(typescript@5.1.6)(zod@3.22.4)
@@ -4261,8 +4261,8 @@ packages:
       react-native: 0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4)(react@18.2.0)
     dev: false
 
-  /@renegade-fi/core@0.0.3(@types/react@18.2.77)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4):
-    resolution: {integrity: sha512-gv3LqIvWhm2J+frWo79NO7B65nyhomqS5rQV1Ktt+6Qwz3CEVl7S2eRG6jjinn5/WWsLsObd4XQjB4lXJ9j5wA==}
+  /@renegade-fi/core@0.0.5(@types/react@18.2.77)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4):
+    resolution: {integrity: sha512-qIzx1cj1dHIT1+BOobcZEeORaZgJ+OAIcb1V67HHWS7u17Cs1tzloRaQPdVd7Xcz1sfga0DloVS/mMWDOm37Sg==}
     dependencies:
       axios: 1.6.8
       isomorphic-ws: 5.0.0(ws@8.13.0)
@@ -4282,8 +4282,8 @@ packages:
       - zod
     dev: false
 
-  /@renegade-fi/react@0.0.3(@tanstack/react-query@5.29.2)(@types/react@18.2.77)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4):
-    resolution: {integrity: sha512-3aU2NdB/bMrmDFGARbjuEGnI5r3tER/+WTjzFbyUm7a3drb1a/UFfmXZG9saawcgiLgWbO0jg9MeChKQoUNDtg==}
+  /@renegade-fi/react@0.0.5(@tanstack/react-query@5.29.2)(@types/react@18.2.77)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4):
+    resolution: {integrity: sha512-qvOGkmulzC8Y6eoY+4lMV7qfKvkfNYVmdmUjttu6HikO7POYaicUICEnB2Ve9+voDrEn0ahI/wnIfqf/RgCg4w==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -4292,7 +4292,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@renegade-fi/core': 0.0.3(@types/react@18.2.77)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4)
+      '@renegade-fi/core': 0.0.5(@types/react@18.2.77)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4)
       '@tanstack/react-query': 5.29.2(react@18.2.0)
       json-bigint: 1.0.0
       react: 18.2.0


### PR DESCRIPTION
This PR executes the pay fees task before the withdrawal task is started. Requires latest SDK version.