### PR TITLE
trade: Pre-testnet main view tweaks

### DIFF
--- a/trade.renegade.fi/app/(desktop)/deposit-button.tsx
+++ b/trade.renegade.fi/app/(desktop)/deposit-button.tsx
@@ -41,33 +41,32 @@ const publicClient = createPublicClient({
 
 export default function DepositButton({
   baseTokenAmount,
+  setBaseTokenAmount,
 }: {
   baseTokenAmount: string
+  setBaseTokenAmount: (baseTokenAmount: string) => void
 }) {
   const [base] = useLocalStorage("base", "WETH", {
     initializeWithValue: false,
   })
-  const {
-    isOpen: signInIsOpen,
-    onOpen: onOpenSignIn,
-    onClose: onCloseSignIn,
-  } = useDisclosure()
+  const [_, setDirection] = useLocalStorage("direction", Direction.BUY)
+  const { isOpen, onOpen, onClose } = useDisclosure()
   const { buttonOnClick, buttonText, cursor, shouldUse } = useButton({
     connectText: "Connect Wallet to Deposit",
-    onOpenSignIn,
+    onOpenSignIn: onOpen,
     signInText: "Sign in to Deposit",
   })
 
   const { address } = useAccount()
+  const queryClient = useQueryClient()
+  const { data: blockNumber } = useBlockNumber({ watch: true })
+  // Get ERC20 balance
+  const { data: balance, queryKey: balanceQueryKey } = useReadErc20BalanceOf({
+    address: Token.findByTicker(base).address,
+    args: [address ?? "0x"],
+  })
 
-  // Get L1 ERC20 balance
-  const { data: l1Balance, queryKey: l1BalanceQueryKey } =
-    useReadErc20BalanceOf({
-      address: Token.findByTicker(base).address,
-      args: [address ?? "0x"],
-    })
-
-  // Get L1 ERC20 Allowance
+  // ERC20 Allowance
   const { data: allowance, queryKey: allowanceQueryKey } =
     useReadErc20Allowance({
       address: Token.findByTicker(base).address,
@@ -77,33 +76,17 @@ export default function DepositButton({
       ],
     })
 
-  const queryClient = useQueryClient()
-  const { data: blockNumber } = useBlockNumber({ watch: true })
   useEffect(() => {
-    queryClient.invalidateQueries({ queryKey: l1BalanceQueryKey })
+    queryClient.invalidateQueries({ queryKey: balanceQueryKey })
     queryClient.invalidateQueries({ queryKey: allowanceQueryKey })
-  }, [allowanceQueryKey, blockNumber, l1BalanceQueryKey, queryClient, base])
+  }, [blockNumber, base, queryClient, balanceQueryKey, allowanceQueryKey])
 
-  // L1 ERC20 Approval
-  const { writeContractAsync: approve, status: approveStatus } =
-    useWriteErc20Approve()
-
-  const { data: walletClient } = useWalletClient()
-
-  const hasRpcConnectionError = typeof allowance === "undefined"
-  const hasInsufficientBalance = l1Balance
-    ? l1Balance < parseAmount(baseTokenAmount, Token.findByTicker(base))
-    : true
-  const needsApproval = allowance === BigInt(0) && approveStatus !== "success"
+  // ERC20 Approval
   const status = useStatus()
   const isConnected = status === "in relayer" && address
-
-  const isDisabled =
-    isConnected &&
-    (!baseTokenAmount || hasRpcConnectionError || hasInsufficientBalance)
-
-  const [_, setDirection] = useLocalStorage("direction", Direction.BUY)
-  const config = useConfig()
+  const { writeContractAsync: approve, status: approveStatus } =
+    useWriteErc20Approve()
+  const { data: walletClient } = useWalletClient()
   const handleApprove = async () => {
     if (!isConnected || !walletClient) return
     const nonce = await publicClient.getTransactionCount({
@@ -119,6 +102,8 @@ export default function DepositButton({
     })
   }
 
+  // Deposit
+  const config = useConfig()
   const taskHistory = useTaskHistory()
   const isQueue = taskHistory.find(
     (task) => task.state !== "Completed" && task.state !== "Failed"
@@ -127,9 +112,7 @@ export default function DepositButton({
     if (!walletClient) return
     const token = Token.findByTicker(base)
     const amount = parseUnits(baseTokenAmount, 18)
-
     const pkRoot = getPkRootScalars(config)
-
     // Generate Permit2 Signature
     const { signature, nonce, deadline } = await signPermit2({
       amount,
@@ -140,6 +123,7 @@ export default function DepositButton({
       walletClient,
       pkRoot,
     })
+    setBaseTokenAmount("")
     if (isQueue) {
       toast.message(QUEUED_DEPOSIT_MSG(token, amount))
     }
@@ -169,6 +153,12 @@ export default function DepositButton({
         console.error(`Error depositing: ${e.response?.data ?? e.message}`)
       })
   }
+
+  const hasInsufficientBalance = balance
+    ? balance < parseAmount(baseTokenAmount, Token.findByTicker(base))
+    : true
+  const isDisabled = isConnected && (!baseTokenAmount || hasInsufficientBalance)
+  const needsApproval = allowance === BigInt(0) || allowance === undefined
 
   const handleClick = async () => {
     if (shouldUse) {
@@ -218,11 +208,9 @@ export default function DepositButton({
           ? "Insufficient balance"
           : needsApproval
           ? `Approve ${base}`
-          : hasRpcConnectionError
-          ? "Error connecting to chain"
-          : `Deposit ${baseTokenAmount || ""} ${base}`}
+          : `Deposit ${baseTokenAmount || "0"} ${base}`}
       </Button>
-      {signInIsOpen && <CreateStepper onClose={onCloseSignIn} />}
+      {isOpen && <CreateStepper onClose={onClose} />}
     </>
   )
 }

--- a/trade.renegade.fi/app/(desktop)/deposit.tsx
+++ b/trade.renegade.fi/app/(desktop)/deposit.tsx
@@ -102,7 +102,7 @@ export function DepositBody() {
             <InputGroup>
               <Input
                 width="200px"
-                paddingRight="3rem"
+                paddingRight={hideMaxButton ? undefined : "3rem"}
                 fontFamily="Favorit"
                 fontSize="0.8em"
                 borderColor="whiteAlpha.300"
@@ -133,6 +133,7 @@ export function DepositBody() {
                     color="white.60"
                     fontFamily="Favorit"
                     fontWeight="400"
+                    borderRadius="100px"
                     onClick={handleSetMax}
                     size="xs"
                     variant="ghost"
@@ -156,7 +157,10 @@ export function DepositBody() {
             </HStack>
           </HStack>
         </Box>
-        <DepositButton baseTokenAmount={baseTokenAmount} />
+        <DepositButton
+          baseTokenAmount={baseTokenAmount}
+          setBaseTokenAmount={setBaseTokenAmount}
+        />
       </Flex>
       <TokenSelectModal isOpen={tokenMenuIsOpen} onClose={onCloseTokenMenu} />
     </>

--- a/trade.renegade.fi/app/(desktop)/footer.tsx
+++ b/trade.renegade.fi/app/(desktop)/footer.tsx
@@ -78,10 +78,11 @@ export const Footer = () => {
         position="absolute"
         bottom="0"
         left="0"
-        color="white.20"
         fontFamily="Favorit Mono"
-        _hover={{ color: "white.100" }}
+        opacity={0.05}
+        _hover={{ opacity: 1 }}
         cursor="pointer"
+        transition="0.2s"
         onClick={() => navigator.clipboard.writeText(walletId ?? "")}
       >
         {walletId}

--- a/trade.renegade.fi/app/(desktop)/trading.tsx
+++ b/trade.renegade.fi/app/(desktop)/trading.tsx
@@ -110,18 +110,6 @@ function TradingInner() {
     }
   }, [base, setBase, view])
 
-  const handleSetBaseTokenAmount = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-    if (
-      value === "" ||
-      (!isNaN(parseFloat(value)) &&
-        isFinite(parseFloat(value)) &&
-        parseFloat(value) >= 0)
-    ) {
-      setBaseTokenAmount(value)
-    }
-  }
-
   return (
     <>
       <Flex
@@ -145,41 +133,10 @@ function TradingInner() {
               activeModal={activeModal}
               ref={buySellSelectableRef}
             />
-            <InputGroup>
-              <Input
-                width="200px"
-                paddingRight="3rem"
-                fontFamily="Favorit"
-                fontSize="0.8em"
-                borderColor="whiteAlpha.300"
-                borderRadius="100px"
-                _focus={{
-                  borderColor: "white.50 !important",
-                  boxShadow: "none !important",
-                }}
-                _placeholder={{ color: "whiteAlpha.400" }}
-                outline="none !important"
-                onChange={handleSetBaseTokenAmount}
-                onFocus={(e) =>
-                  e.target.addEventListener(
-                    "wheel",
-                    (e) => e.preventDefault(),
-                    {
-                      passive: false,
-                    }
-                  )
-                }
-                placeholder="0.00"
-                type="number"
-                value={baseTokenAmount || ""}
-              />
-              <InputRightElement width="3.5rem">
-                <MaxButton
-                  baseTokenAmount={baseTokenAmount}
-                  setBaseTokenAmount={setBaseTokenAmount}
-                />
-              </InputRightElement>
-            </InputGroup>
+            <InputWithMaxButton
+              baseTokenAmount={baseTokenAmount}
+              setBaseTokenAmount={setBaseTokenAmount}
+            />
             <HStack
               userSelect="none"
               cursor="pointer"
@@ -206,7 +163,10 @@ function TradingInner() {
           </HStack>
           <HelperText baseTicker={base} />
         </Flex>
-        <PlaceOrderButton baseTokenAmount={baseTokenAmount} />
+        <PlaceOrderButton
+          baseTokenAmount={baseTokenAmount}
+          setBaseTokenAmount={setBaseTokenAmount}
+        />
         <BlurredOverlay
           activeModal={activeModal}
           onClose={() => setActiveModal(undefined)}
@@ -238,14 +198,14 @@ function HelperText({ baseTicker }: { baseTicker: string }) {
   )
 }
 
-function MaxButton({
+function InputWithMaxButton({
   baseTokenAmount,
   setBaseTokenAmount,
 }: {
   baseTokenAmount: string
   setBaseTokenAmount: (value: string) => void
 }) {
-  const [base] = useLocalStorage("base", Token.findByTicker("WETH").ticker, {
+  const [base] = useLocalStorage("base", "WETH", {
     initializeWithValue: false,
   })
   const [quote] = useLocalStorage("quote", "USDC", {
@@ -255,6 +215,18 @@ function MaxButton({
   const max = useMax(direction === Direction.SELL ? base : quote)
   const usdPrice = useUSDPrice(base, 1)
   const buyMax = (1 / usdPrice) * Number(max) * 0.99
+
+  const handleSetBaseTokenAmount = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    if (
+      value === "" ||
+      (!isNaN(parseFloat(value)) &&
+        isFinite(parseFloat(value)) &&
+        parseFloat(value) >= 0)
+    ) {
+      setBaseTokenAmount(value)
+    }
+  }
 
   const handleSetMax = () => {
     if (max) {
@@ -270,17 +242,47 @@ function MaxButton({
     (direction === Direction.SELL
       ? baseTokenAmount === max
       : baseTokenAmount === buyMax.toString())
-  if (hideMaxButton) return null
+
   return (
-    <Button
-      color="white.60"
-      fontFamily="Favorit"
-      fontWeight="400"
-      onClick={handleSetMax}
-      size="xs"
-      variant="ghost"
-    >
-      Max
-    </Button>
+    <InputGroup>
+      <Input
+        width="200px"
+        paddingRight={hideMaxButton ? undefined : "3rem"}
+        fontFamily="Favorit"
+        fontSize="0.8em"
+        borderColor="whiteAlpha.300"
+        borderRadius="100px"
+        _focus={{
+          borderColor: "white.50 !important",
+          boxShadow: "none !important",
+        }}
+        _placeholder={{ color: "whiteAlpha.400" }}
+        outline="none !important"
+        onChange={handleSetBaseTokenAmount}
+        onFocus={(e) =>
+          e.target.addEventListener("wheel", (e) => e.preventDefault(), {
+            passive: false,
+          })
+        }
+        placeholder="0.00"
+        type="number"
+        value={baseTokenAmount || ""}
+      />
+      {!hideMaxButton && (
+        <InputRightElement width="3.5rem">
+          <Button
+            color="white.60"
+            fontFamily="Favorit"
+            fontWeight="400"
+            borderRadius="100px"
+            onClick={handleSetMax}
+            size="xs"
+            variant="ghost"
+          >
+            Max
+          </Button>
+        </InputRightElement>
+      )}
+    </InputGroup>
   )
 }

--- a/trade.renegade.fi/app/(desktop)/withdraw-button.tsx
+++ b/trade.renegade.fi/app/(desktop)/withdraw-button.tsx
@@ -23,9 +23,11 @@ import { CreateStepper } from "@/components/steppers/create-stepper/create-stepp
 export default function WithdrawButton({
   baseTicker,
   baseTokenAmount,
+  setBaseTokenAmount,
 }: {
   baseTicker: string
   baseTokenAmount: string
+  setBaseTokenAmount: (baseTokenAmount: string) => void
 }) {
   const {
     isOpen: signInIsOpen,
@@ -53,7 +55,7 @@ export default function WithdrawButton({
   const status = useStatus()
   const isConnected = status === "in relayer"
 
-  const isDisabled = (isConnected && !baseTokenAmount) || hasInsufficientBalance
+  const isDisabled = isConnected && (!baseTokenAmount || hasInsufficientBalance)
 
   const config = useConfig()
   const { address } = useAccount()
@@ -68,6 +70,7 @@ export default function WithdrawButton({
     if (!address) return
     const token = Token.findByTicker(baseTicker)
     const amount = parseAmount(baseTokenAmount, token)
+    setBaseTokenAmount("")
     if (isQueue) {
       toast.message(QUEUED_WITHDRAWAL_MSG(token, amount))
     }

--- a/trade.renegade.fi/app/(desktop)/withdraw.tsx
+++ b/trade.renegade.fi/app/(desktop)/withdraw.tsx
@@ -87,7 +87,7 @@ export function WithdrawBody() {
             <InputGroup>
               <Input
                 width="200px"
-                paddingRight="3rem"
+                paddingRight={hideMaxButton ? undefined : "3rem"}
                 fontFamily="Favorit"
                 fontSize="0.8em"
                 borderColor="whiteAlpha.300"
@@ -118,6 +118,7 @@ export function WithdrawBody() {
                     color="white.60"
                     fontFamily="Favorit"
                     fontWeight="400"
+                    borderRadius="100px"
                     onClick={handleSetMax}
                     size="xs"
                     variant="ghost"
@@ -141,7 +142,11 @@ export function WithdrawBody() {
             </HStack>
           </HStack>
         </Box>
-        <WithdrawButton baseTicker={base} baseTokenAmount={baseTokenAmount} />
+        <WithdrawButton
+          baseTicker={base}
+          baseTokenAmount={baseTokenAmount}
+          setBaseTokenAmount={setBaseTokenAmount}
+        />
       </Flex>
       <TokenSelectModal isOpen={tokenMenuIsOpen} onClose={onCloseTokenMenu} />
     </>

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -26,7 +26,7 @@ import "simplebar-react/dist/simplebar.min.css"
 import { toast } from "sonner"
 import { useLocalStorage } from "usehooks-ts"
 import { Address, formatUnits } from "viem"
-import { useAccount as useAccountWagmi, useWalletClient } from "wagmi"
+import { useAccount as useAccountWagmi } from "wagmi"
 
 import { useUSDPrice } from "@/hooks/use-usd-price"
 
@@ -39,13 +39,11 @@ interface TokenBalanceProps {
   amount: bigint
 }
 function TokenBalance(props: TokenBalanceProps) {
-  const { tokenIcons } = useApp()
-  const { setView } = useApp()
+  const { setView, tokenIcons } = useApp()
   const token = Token.findByAddress(props.tokenAddr)
-  const [_, setBase] = useLocalStorage(
-    "base",
-    Token.findByTicker("WETH").ticker
-  )
+  const [_, setBase] = useLocalStorage("base", "WETH", {
+    initializeWithValue: false,
+  })
 
   const formattedAmount = formatAmount(props.amount, token)
   const ticker = token.ticker
@@ -56,18 +54,9 @@ function TokenBalance(props: TokenBalanceProps) {
 
   const isZero = props.amount === BigInt(0)
 
-  const { data: walletClient } = useWalletClient()
-  const handleAddToWallet = async (address: Address) => {
-    if (!walletClient) return
-    const token = Token.findByAddress(address)
-    await walletClient.watchAsset({
-      type: "ERC20",
-      options: {
-        address,
-        decimals: token.decimals || 18,
-        symbol: "DUMMY",
-      },
-    })
+  const handleClick = () => {
+    setBase(ticker)
+    setView(ViewEnum.TRADING)
   }
 
   return (
@@ -94,7 +83,7 @@ function TokenBalance(props: TokenBalanceProps) {
         marginLeft="5px"
         fontFamily="Favorit"
         cursor="pointer"
-        onClick={() => handleAddToWallet(props.tokenAddr)}
+        onClick={handleClick}
       >
         <Tooltip
           backgroundColor="white"
@@ -377,7 +366,7 @@ function HistorySection() {
       </Flex>
       <SimpleBar
         style={{
-          minHeight: "30vh",
+          height: "30vh",
           width: "100%",
           padding: "0 8px",
         }}

--- a/trade.renegade.fi/package.json
+++ b/trade.renegade.fi/package.json
@@ -22,7 +22,7 @@
     "@datadog/browser-rum": "^5.15.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@renegade-fi/react": "0.0.12",
+    "@renegade-fi/react": "^0.0.12",
     "@t3-oss/env-nextjs": "^0.6.0",
     "@tanstack/react-query": "^5.24.1",
     "@vercel/analytics": "^1.2.2",

--- a/trade.renegade.fi/pnpm-lock.yaml
+++ b/trade.renegade.fi/pnpm-lock.yaml
@@ -30,7 +30,7 @@ dependencies:
     specifier: ^11.11.0
     version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.2.77)(react@18.2.0)
   '@renegade-fi/react':
-    specifier: 0.0.12
+    specifier: ^0.0.12
     version: 0.0.12(@tanstack/react-query@5.29.2)(@types/react@18.2.77)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4)
   '@t3-oss/env-nextjs':
     specifier: ^0.6.0


### PR DESCRIPTION
This PR adds the following:

- clear input after submitting (deposit, withdraw, place order)
- only show insufficient balance if renegade balance is 0
- fixes padding of max button
- ensures allowance is fetched when base changes, and when there's a new block
- airdrop button clickable when task history is long
- clicking on balance in wallets panel navigates to trade page