### PR TITLE
trade: fetch TVL from onchain

### DIFF
--- a/trade.renegade.fi/components/banners/relayer-banner.tsx
+++ b/trade.renegade.fi/components/banners/relayer-banner.tsx
@@ -7,7 +7,9 @@ import {
   RELAYER_NAME_TOOLTIP,
   TVL_TOOLTIP,
 } from "@/lib/tooltip-labels"
+import { formatNumber } from "@/lib/utils"
 import { Box, Flex, HStack, Spacer, Text } from "@chakra-ui/react"
+import { Token } from "@renegade-fi/react"
 import React from "react"
 
 import { Tooltip } from "@/components/tooltip"
@@ -19,6 +21,8 @@ interface RelayerStatusBannerProps {
   activeBaseTicker: string
   activeQuoteTicker: string
   connectionState?: "live" | "dead" | "loading"
+  baseTvl: bigint
+  quoteTvl: bigint
 }
 interface RelayerStatusBannerState {
   relayerStatusBannerRef: React.RefObject<HTMLDivElement>
@@ -174,15 +178,45 @@ export class RelayerStatusBanner extends React.Component<
           height="var(--banner-height)"
         >
           <Spacer flexGrow="2" />
-          <Tooltip placement="bottom" label={TVL_TOOLTIP}>
-            <Flex alignItems="center" gap="3">
+          <Flex alignItems="center" gap="3">
+            <Tooltip placement="bottom" label={TVL_TOOLTIP}>
               <Text>TVL</Text>
-              <BannerSeparator flexGrow={1} />
-              <Text>123.456 {this.props.activeBaseTicker}</Text>
-              <BannerSeparator flexGrow={1} />
-              <Text>123456.78 {this.props.activeQuoteTicker}</Text>
-            </Flex>
-          </Tooltip>
+            </Tooltip>
+            <BannerSeparator flexGrow={1} />
+            <Tooltip
+              placement="bottom"
+              label={`${formatNumber(
+                this.props.baseTvl,
+                Token.findByTicker(this.props.activeBaseTicker).decimals,
+                true
+              )} ${this.props.activeBaseTicker}`}
+            >
+              <Text>
+                {formatNumber(
+                  this.props.baseTvl,
+                  Token.findByTicker(this.props.activeBaseTicker).decimals
+                )}{" "}
+                {this.props.activeBaseTicker}
+              </Text>
+            </Tooltip>
+            <BannerSeparator flexGrow={1} />
+            <Tooltip
+              placement="bottom"
+              label={`${formatNumber(
+                this.props.quoteTvl,
+                Token.findByTicker(this.props.activeQuoteTicker).decimals,
+                true
+              )} ${this.props.activeQuoteTicker}`}
+            >
+              <Text>
+                {formatNumber(
+                  this.props.quoteTvl,
+                  Token.findByTicker(this.props.activeQuoteTicker).decimals
+                )}{" "}
+                {this.props.activeQuoteTicker}
+              </Text>
+            </Tooltip>
+          </Flex>
           <BannerSeparator flexGrow={3} />
           <Tooltip placement="bottom" label={RELAYER_NAME_TOOLTIP}>
             <Flex alignItems="center" gap="3">

--- a/trade.renegade.fi/components/banners/relayer-status-data.tsx
+++ b/trade.renegade.fi/components/banners/relayer-status-data.tsx
@@ -4,6 +4,8 @@ import { env } from "@/env.mjs"
 import { useEffect, useState } from "react"
 import { useLocalStorage } from "usehooks-ts"
 
+import { useTvl } from "@/hooks/use-tvl"
+
 import { RelayerStatusBanner } from "@/components/banners/relayer-banner"
 
 export function RelayerStatusData() {
@@ -12,6 +14,8 @@ export function RelayerStatusData() {
   const [quote] = useLocalStorage("quote", "USDC", {
     initializeWithValue: false,
   })
+  const baseTvl = useTvl(base)
+  const quoteTvl = useTvl(quote)
 
   useEffect(() => {
     const fetchPing = async () => {
@@ -45,6 +49,8 @@ export function RelayerStatusData() {
       connectionState={ping}
       activeBaseTicker={base}
       activeQuoteTicker={quote}
+      baseTvl={baseTvl}
+      quoteTvl={quoteTvl}
     />
   )
 }

--- a/trade.renegade.fi/hooks/use-tvl.ts
+++ b/trade.renegade.fi/hooks/use-tvl.ts
@@ -1,0 +1,45 @@
+import { renegadeConfig } from "@/app/providers"
+import { env } from "@/env.mjs"
+import { Token, chain } from "@renegade-fi/react"
+import { useCallback, useEffect, useState } from "react"
+import { Address, createPublicClient, http, parseAbi } from "viem"
+
+const abi = parseAbi([
+  "function balanceOf(address owner) view returns (uint256)",
+])
+
+const publicClient = createPublicClient({
+  chain,
+  transport: http(),
+})
+
+export const useTvl = (ticker: string) => {
+  const [data, setData] = useState<bigint>(BigInt(0))
+
+  const fetchBalance = useCallback(async () => {
+    const balance = await publicClient.readContract({
+      address: Token.findByTicker(ticker).address,
+      abi,
+      functionName: "balanceOf",
+      args: [env.NEXT_PUBLIC_DARKPOOL_CONTRACT as Address],
+    })
+    setData(balance)
+  }, [ticker])
+
+  useEffect(() => {
+    fetchBalance()
+
+    const intervalId = setInterval(fetchBalance, renegadeConfig.pollingInterval)
+
+    return () => clearInterval(intervalId)
+  }, [fetchBalance, ticker])
+  return data
+}
+
+// Causes Chain not Configured Error, reenable when fixed
+// const { data: blockNumber } = useBlockNumber({ watch: true })
+// const queryClient = useQueryClient()
+// useEffect(() => {
+//   const intervalId = setInterval(() => {
+//     queryClient.invalidateQueries({ queryKey })
+//   }, 10000)

--- a/trade.renegade.fi/lib/utils.ts
+++ b/trade.renegade.fi/lib/utils.ts
@@ -44,7 +44,7 @@ export const formatNumber = (
 
   let formatStr = ""
   if (balanceValue > 10000000) {
-    formatStr = "0.00a"
+    formatStr = long ? "0,0[.]00" : "0.00a"
   } else if (balanceValue > 1000000) {
     formatStr = `0${long ? ".[00]" : ""}`
   } else if (balanceValue > 10000) {


### PR DESCRIPTION
This PR adds fetching live TVL data from the darkpool contract onchain. The correct implementation would use `useBlockNumber` to invalidate the cache on each new block, but this causes a `Chain not Configured` wagmi error when the `wagmi.store` key is not present in localstorage. For now, we fetch on a 10s interval.