### PR TITLE
trade: standardize text color

### DIFF
--- a/trade.renegade.fi/app/(desktop)/deposit.tsx
+++ b/trade.renegade.fi/app/(desktop)/deposit.tsx
@@ -95,7 +95,7 @@ export function DepositBody() {
                 <ChevronLeftIcon />
                 Back to Trading
               </Button>
-              <Text color="white.50" fontSize="34px">
+              <Text color="text.secondary" fontSize="34px">
                 Deposit
               </Text>
             </div>
@@ -130,7 +130,7 @@ export function DepositBody() {
               {!hideMaxButton && (
                 <InputRightElement width="3.5rem">
                   <Button
-                    color="white.60"
+                    color="text.secondary"
                     fontFamily="Favorit"
                     fontWeight="400"
                     borderRadius="100px"
@@ -149,11 +149,7 @@ export function DepositBody() {
               onClick={onOpenTokenMenu}
             >
               <Text variant="trading-body-button">{base}</Text>
-              <ChevronDownIcon
-                boxSize="20px"
-                viewBox="6 6 12 12"
-                color="white.100"
-              />
+              <ChevronDownIcon boxSize="20px" viewBox="6 6 12 12" />
             </HStack>
           </HStack>
         </Box>

--- a/trade.renegade.fi/app/(desktop)/footer.tsx
+++ b/trade.renegade.fi/app/(desktop)/footer.tsx
@@ -63,7 +63,7 @@ export const Footer = () => {
         <Text
           position="absolute"
           left="50%"
-          color="white.90"
+          color="text.primary"
           fontSize="1.1em"
           fontWeight="300"
           transform="translateX(-50%)"
@@ -76,11 +76,10 @@ export const Footer = () => {
         position="absolute"
         bottom="0"
         left="0"
+        color="white.10"
         fontFamily="Favorit Mono"
-        opacity={0.05}
-        _hover={{ opacity: 1 }}
+        _hover={{ color: "text.primary" }}
         cursor="pointer"
-        transition="0.2s"
         onClick={() => navigator.clipboard.writeText(walletId ?? "")}
       >
         {walletId}

--- a/trade.renegade.fi/app/(desktop)/trading.tsx
+++ b/trade.renegade.fi/app/(desktop)/trading.tsx
@@ -48,7 +48,7 @@ const Selectable = React.forwardRef(
         >
           {props.text}
         </Text>
-        <ChevronDownIcon boxSize="20px" viewBox="6 6 12 12" color="white.100" />
+        <ChevronDownIcon boxSize="20px" viewBox="6 6 12 12" />
       </HStack>
     )
   }
@@ -145,14 +145,10 @@ function TradingInner() {
               <Text cursor="pointer" variant="trading-body-button">
                 {base}
               </Text>
-              <ChevronDownIcon
-                boxSize="20px"
-                viewBox="6 6 12 12"
-                color="white.100"
-              />
+              <ChevronDownIcon boxSize="20px" viewBox="6 6 12 12" />
             </HStack>
             <Text
-              color="white.50"
+              color="text.secondary"
               fontFamily="Favorit"
               fontSize="0.9em"
               fontWeight="200"
@@ -185,7 +181,7 @@ function HelperText({ baseTicker }: { baseTicker: string }) {
   const usdPrice = useUSDPrice(baseTicker, 1)
   const formattedUsdPrice = numeral(usdPrice).format("$0.00")
   return (
-    <Text color="white.50" fontWeight="100" userSelect="text">
+    <Text color="text.muted" fontWeight="100" userSelect="text">
       Trades are end-to-end encrypted and always clear at the real-time midpoint
       of {formattedUsdPrice}
     </Text>
@@ -265,7 +261,7 @@ function InputWithMaxButton({
       {!hideMaxButton && (
         <InputRightElement width="3.5rem">
           <Button
-            color="white.60"
+            color="text.secondary"
             fontFamily="Favorit"
             fontWeight="400"
             borderRadius="100px"

--- a/trade.renegade.fi/app/(desktop)/withdraw.tsx
+++ b/trade.renegade.fi/app/(desktop)/withdraw.tsx
@@ -80,7 +80,7 @@ export function WithdrawBody() {
                 <ChevronLeftIcon />
                 Back to Trading
               </Button>
-              <Text color="white.50" fontSize="34px">
+              <Text color="text.secondary" fontSize="34px">
                 Withdraw
               </Text>
             </div>
@@ -115,7 +115,7 @@ export function WithdrawBody() {
               {!hideMaxButton && (
                 <InputRightElement width="3.5rem">
                   <Button
-                    color="white.60"
+                    color="text.secondary"
                     fontFamily="Favorit"
                     fontWeight="400"
                     borderRadius="100px"
@@ -134,11 +134,7 @@ export function WithdrawBody() {
               onClick={onOpenTokenMenu}
             >
               <Text variant="trading-body-button">{base}</Text>
-              <ChevronDownIcon
-                boxSize="20px"
-                viewBox="6 6 12 12"
-                color="white.100"
-              />
+              <ChevronDownIcon boxSize="20px" viewBox="6 6 12 12" />
             </HStack>
           </HStack>
         </Box>

--- a/trade.renegade.fi/app/providers.tsx
+++ b/trade.renegade.fi/app/providers.tsx
@@ -93,6 +93,11 @@ const colors = {
   "white.20": "#333333",
   "white.10": "#1a1a1a",
   "white.5": "#0d0d0d",
+  text: {
+    primary: "#cccccc",
+    secondary: "#999999",
+    muted: "#666666",
+  },
   surfaces: {
     1: "#1e1e1e",
   },

--- a/trade.renegade.fi/components/banner-separator.tsx
+++ b/trade.renegade.fi/components/banner-separator.tsx
@@ -6,7 +6,12 @@ interface BannerSeparatorProps {
 export function BannerSeparator(props: BannerSeparatorProps) {
   return (
     <Center flexGrow={props.flexGrow || 4} height="100%">
-      <Box width="4px" height="4px" background="white.80" borderRadius="2px" />
+      <Box
+        width="4px"
+        height="4px"
+        background="text.secondary"
+        borderRadius="2px"
+      />
     </Center>
   )
 }

--- a/trade.renegade.fi/components/banners/median-banner.tsx
+++ b/trade.renegade.fi/components/banners/median-banner.tsx
@@ -401,7 +401,7 @@ export class MedianBanner extends React.Component<
           this.props.isMobile ? "calc(0.75 * var(--banner-height))" : "100%"
         }
         height={this.props.isMobile ? "220vw" : "var(--banner-height)"}
-        color="white.80"
+        color="text.primary"
         fontSize={this.props.isMobile ? "0.8em" : undefined}
         borderColor="border"
         borderBottom={this.props.isMobile ? undefined : "var(--border)"}

--- a/trade.renegade.fi/components/banners/relayer-banner.tsx
+++ b/trade.renegade.fi/components/banners/relayer-banner.tsx
@@ -158,7 +158,7 @@ export class RelayerStatusBanner extends React.Component<
         ref={this.state.relayerStatusBannerRef}
         overflow="hidden"
         height="var(--banner-height)"
-        color="white.80"
+        color="text.primary"
         borderBottom="var(--border)"
         userSelect="text"
         onMouseDown={this.onMouseDown}

--- a/trade.renegade.fi/components/banners/tokens-banner.tsx
+++ b/trade.renegade.fi/components/banners/tokens-banner.tsx
@@ -34,16 +34,16 @@ export function TokensBanner({}: { prices?: number[] }) {
             direction="row"
             marginRight="0.5rem"
             padding="4px 8px"
+            color="text.primary"
             borderRadius="0.5rem"
             _hover={{
               backgroundColor: "white.10",
+              color: "text.primary",
             }}
-            transition="background 0.3s cubic-bezier(0.215, 0.61, 0.355, 1)"
+            transition="background-color 0.3s ease"
             onClick={() => setBaseToken(ticker)}
           >
-            <Text color="white.80" fontFamily="Favorit Expanded">
-              {ticker}
-            </Text>
+            <Text fontFamily="Favorit Expanded">{ticker}</Text>
             <LivePrices
               baseTicker={ticker}
               quoteTicker="USDC"

--- a/trade.renegade.fi/components/live-price.tsx
+++ b/trade.renegade.fi/components/live-price.tsx
@@ -137,14 +137,14 @@ export const LivePrices = ({
         justifyContent="center"
         flexGrow="1"
         width={isMobile ? "100%" : undefined}
-        color="white.80"
+        color="inherit"
         fontFamily="Favorit Mono"
         lineHeight="1"
         opacity={price === 0 ? "20%" : "100%"}
         _hover={{ textDecoration: "none" }}
         transform={isMobile && shouldRotate ? "rotate(180deg)" : undefined}
       >
-        ${priceStr}
+        <Text>${priceStr}</Text>
       </Flex>
       <Flex
         position="relative"

--- a/trade.renegade.fi/components/modals/blurred-overlay.tsx
+++ b/trade.renegade.fi/components/modals/blurred-overlay.tsx
@@ -19,7 +19,7 @@ export function BlurredOverlay({
     return (
       <Text
         margin="-10px 0 -5px 0"
-        color="white.70"
+        color="text.secondary"
         fontFamily="Aime"
         fontSize="0.8em"
       >

--- a/trade.renegade.fi/components/modals/token-select-modal.tsx
+++ b/trade.renegade.fi/components/modals/token-select-modal.tsx
@@ -45,16 +45,15 @@ export function TokenSelectModal({
       />
       <ModalContent
         height="592px"
-        fontFamily="Favorit"
-        fontSize="1.2em"
         background="white.5"
         border="var(--border)"
         borderColor="white.30"
       >
-        <ModalHeader>
+        <ModalHeader color="text.primary">
           Select a Token
           <Input
             marginTop={4}
+            fontFamily="Favorit"
             borderColor="whiteAlpha.300"
             _focus={{
               borderColor: "white.50 !important",
@@ -72,7 +71,7 @@ export function TokenSelectModal({
           {addressAndBalances.length === 0 && (
             <Box display="grid" minHeight="80%" placeContent="center">
               <Text
-                color="white.50"
+                color="text.secondary"
                 fontFamily="Favorit Extended"
                 fontSize="1.2em"
               >
@@ -117,18 +116,19 @@ const Row = ({ address, onClick, balance }: RowProps) => {
   const ticker = Token.findByAddress(address).ticker
   return (
     <Grid
-      className="wrapper"
       key={address}
       position="relative"
       alignItems="center"
       gridTemplateColumns="2fr 1fr"
       overflow="hidden"
       height={ROW_HEIGHT}
+      color="text.primary"
+      fontFamily="Favorit"
+      fontSize="1.2em"
       _hover={{
         backgroundColor: "white.10",
       }}
       cursor="pointer"
-      transition="0.1s"
       onClick={onClick}
       paddingX="5"
     >
@@ -143,7 +143,7 @@ const Row = ({ address, onClick, balance }: RowProps) => {
           />
           <VStack alignItems="start" gap="0">
             <Text>{TICKER_TO_NAME[ticker]}</Text>
-            <Text color="white.60" fontSize="0.7em">
+            <Text color="text.secondary" fontSize="0.7em">
               {ticker}
             </Text>
           </VStack>
@@ -151,9 +151,7 @@ const Row = ({ address, onClick, balance }: RowProps) => {
       </GridItem>
       <GridItem>
         <Box textAlign="right">
-          <Text color="white.50" fontFamily="Favorit Mono">
-            {balance}
-          </Text>
+          <Text fontFamily="Favorit Mono">{balance}</Text>
         </Box>
       </GridItem>
     </Grid>

--- a/trade.renegade.fi/components/panels/orders-panel.tsx
+++ b/trade.renegade.fi/components/panels/orders-panel.tsx
@@ -13,7 +13,7 @@ import {
   ORDER_TOOLTIP,
 } from "@/lib/tooltip-labels"
 import { formatNumber } from "@/lib/utils"
-import { LockIcon, SmallCloseIcon, UnlockIcon } from "@chakra-ui/icons"
+import { Icon, LockIcon, UnlockIcon } from "@chakra-ui/icons"
 import { Box, Flex, Image, Text } from "@chakra-ui/react"
 import {
   NetworkOrder,
@@ -32,6 +32,7 @@ import {
 } from "@renegade-fi/react"
 import { useModal as useModalConnectKit } from "connectkit"
 import dayjs from "dayjs"
+import { X } from "lucide-react"
 import React, { useMemo } from "react"
 import SimpleBar from "simplebar-react"
 import "simplebar-react/dist/simplebar.min.css"
@@ -103,22 +104,25 @@ function SingleOrder({ order }: { order: OrderMetadata }) {
         gap="4%"
         width="100%"
         padding="5%"
-        color="white.60"
-        borderColor="white.20"
+        color={isCancellable ? "text.secondary" : "text.muted"}
+        fontSize="0.8em"
         borderBottom="var(--secondary-border)"
         _hover={{
           filter: "inherit",
-          color: "white.90",
+          color: "text.primary",
         }}
-        transition="all 0.2s"
+        whiteSpace="nowrap"
+        transition="filter 0.3s ease"
         filter={isCancellable ? "inherit" : "grayscale(1)"}
       >
-        <Text fontFamily="Favorit">{formattedState}</Text>
+        <Text fontFamily="Favorit" fontSize="1.2em">
+          {formattedState}
+        </Text>
         <Box position="relative" width="45px" height="40px">
           <Image
             width="25px"
             height="25px"
-            alt="Quote logo"
+            alt=""
             src={tokenIcons[quote.ticker]}
           />
           <Image
@@ -127,33 +131,28 @@ function SingleOrder({ order }: { order: OrderMetadata }) {
             bottom="1"
             width="25px"
             height="25px"
-            alt="Base logo"
+            alt=""
             src={tokenIcons[base.ticker]}
           />
         </Box>
-        <Flex
-          alignItems="flex-start"
-          flexDirection="column"
-          fontFamily="Favorit"
-        >
-          <Text lineHeight="1">
+        <Flex alignItems="flex-start" flexDirection="column" lineHeight="1">
+          <Text fontFamily="Favorit" fontSize="1.4em">
             {formattedAmount} {base.ticker}
           </Text>
-          <Text fontFamily="Favorit Extended" fontSize="0.9em" fontWeight="200">
-            {side.toUpperCase()}
-          </Text>
+          <Text>{side.toUpperCase()}</Text>
         </Flex>
         {isCancellable ? (
-          <SmallCloseIcon
-            width="calc(0.5 * var(--banner-height))"
-            height="calc(0.5 * var(--banner-height))"
-            borderRadius="100px"
-            cursor="pointer"
-            _hover={{
-              background: "white.10",
-            }}
-            onClick={handleCancel}
-          />
+          <Tooltip label="Cancel Order">
+            <Icon
+              as={X}
+              color="text.secondary"
+              cursor="pointer"
+              _hover={{
+                color: "text.muted",
+              }}
+              onClick={handleCancel}
+            />
+          </Tooltip>
         ) : null}
       </Flex>
     </Tooltip>
@@ -175,7 +174,7 @@ function OrdersPanel(props: OrdersPanelProps) {
         <Text
           margin="auto"
           padding="0 10%"
-          color="white.50"
+          color="text.secondary"
           fontSize="0.8em"
           fontWeight="100"
           textAlign="center"
@@ -190,7 +189,7 @@ function OrdersPanel(props: OrdersPanelProps) {
     return (
       <SimpleBar
         style={{
-          height: "calc(100% - 30vh -  (3 * var(--banner-height)))",
+          height: "calc(100% - 30vh - (3 * var(--banner-height)))",
           width: "100%",
           padding: "0 8px",
         }}
@@ -215,25 +214,24 @@ function OrdersPanel(props: OrdersPanelProps) {
         >
           <Flex
             position="absolute"
-            left="10px"
+            top="12px"
+            left="29px"
             alignItems="center"
-            justifyContent="center"
-            width="calc(0.6 * var(--banner-height))"
-            height="calc(0.6 * var(--banner-height))"
-            borderRadius="100px"
+            color="text.primary"
             _hover={{
-              background: "white.10",
+              color: "text.secondary",
             }}
             cursor="pointer"
+            transition="color 0.3s ease"
             onClick={props.toggleIsLocked}
           >
             {props.isLocked ? (
-              <LockIcon boxSize="11px" color="white.80" />
+              <LockIcon boxSize="11px" />
             ) : (
-              <UnlockIcon boxSize="11px" color="white.80" />
+              <UnlockIcon boxSize="11px" />
             )}
           </Flex>
-          <Text>Order History</Text>
+          <Text color="text.primary">Orders</Text>
         </Flex>
       </Tooltip>
       {Content}
@@ -254,7 +252,7 @@ function OrderBookPanel() {
       <Box display="grid" height="30vh" placeContent="center">
         <Text
           padding="0 10%"
-          color="white.50"
+          color="text.secondary"
           fontSize="0.8em"
           fontWeight="100"
           textAlign="center"
@@ -275,51 +273,46 @@ function OrderBookPanel() {
         {Object.values(networkOrders).map((counterpartyOrder) => {
           const title = formatTitle(orders, counterpartyOrder)
           const status = orders.find(({ id }) => id === counterpartyOrder.id)
-            ? "ACTIVE"
+            ? "Active"
             : matchedOrders.some(({ id }) => id === counterpartyOrder.id)
-            ? "MATCHED"
+            ? "Matched"
             : counterpartyOrder.state === "Cancelled"
-            ? "VERIFIED"
-            : counterpartyOrder.state.toUpperCase()
+            ? "Verified"
+            : counterpartyOrder.state
 
           const timestamp = counterpartyOrder.timestamp
           const textColor =
-            status === "ACTIVE" || status === "MATCHED"
+            status === "Active" || status === "Matched"
               ? "green"
-              : status === "CANCELLED"
+              : status === "Cancelled"
               ? "red"
-              : "white.60"
+              : undefined
 
           return (
             <Box
               key={counterpartyOrder.id}
               padding="5%"
+              color="text.secondary"
+              fontSize="0.8em"
               borderBottom="var(--secondary-border)"
+              _hover={{
+                filter: "inherit",
+                color: "text.primary",
+              }}
+              role="group"
             >
               <Flex
                 alignItems="center"
                 justifyContent="space-between"
                 minWidth="100%"
+                whiteSpace="nowrap"
               >
-                <Text
-                  color={textColor}
-                  fontFamily="Favorit Extended"
-                  fontWeight="500"
-                >
+                <Text fontSize="1.2em" _groupHover={{ color: textColor }}>
                   {status}&nbsp;
                 </Text>
-                <Text
-                  color="white.60"
-                  fontFamily="Favorit Expanded"
-                  fontSize="0.7em"
-                  fontWeight="500"
-                >
-                  {dayjs.unix(Number(timestamp)).fromNow()}
-                </Text>
+                <Text>{dayjs.unix(Number(timestamp)).fromNow()}</Text>
               </Flex>
-              <Text color="white.80" fontSize="0.8em">
-                {title}
-              </Text>
+              <Text>{title}</Text>
             </Box>
           )
         })}
@@ -340,7 +333,7 @@ function OrderBookPanel() {
           borderTop="var(--border)"
           borderBottom="var(--border)"
         >
-          <Text>Order Book</Text>
+          <Text color="text.primary">Order Book</Text>
         </Flex>
       </Tooltip>
       {panelBody}
@@ -358,6 +351,7 @@ function CounterpartiesPanel() {
         justifyContent="center"
         width="100%"
         minHeight="var(--banner-height)"
+        color="text.primary"
         borderColor="border"
         borderTop="var(--border)"
       >

--- a/trade.renegade.fi/components/panels/task-item.tsx
+++ b/trade.renegade.fi/components/panels/task-item.tsx
@@ -32,22 +32,23 @@ export function TaskItem({
     )
 
   const iconColor =
-    state === "Completed" ? "green" : state === "Failed" ? "red" : "white.90"
+    state === "Completed"
+      ? "green"
+      : state === "Failed"
+      ? "red"
+      : "text.primary"
 
   return (
     <Tooltip placement="right" label={isFeeTask ? FEES_TOOLTIP : ""}>
       <Box
         justifyContent="center"
         padding="4% 6%"
-        color="white.60"
+        color="text.secondary"
         fontSize="0.8em"
-        borderColor="white.20"
         borderBottom="var(--secondary-border)"
         _hover={{
-          filter: "inherit",
-          color: "white.90",
+          color: "text.primary",
         }}
-        transition="all 0.2s"
         role="group"
       >
         <Flex
@@ -56,11 +57,12 @@ export function TaskItem({
           minWidth="100%"
           whiteSpace="nowrap"
         >
-          <Text fontFamily="Favorit Extended" fontSize="1.2em" fontWeight="500">
-            {name}
-          </Text>
+          <Text fontSize="1.2em">{name}</Text>
           <Flex gap="1" verticalAlign="middle">
-            <Box _groupHover={{ color: iconColor }} transition="color 0.2s">
+            <Box
+              _groupHover={{ color: iconColor }}
+              transition="color 0.3s ease"
+            >
               {icon}
             </Box>
             <Text>{state}</Text>

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -73,14 +73,9 @@ function TokenBalance(props: TokenBalanceProps) {
       gap="5px"
       width="100%"
       padding="5% 6%"
-      color="white.60"
-      borderColor="white.20"
+      color="text.secondary"
       borderBottom="var(--secondary-border)"
-      _hover={{
-        color: isZero ? undefined : "white.90",
-      }}
       boxSizing="border-box"
-      transition="all 0.2s"
       filter={isZero ? "grayscale(1)" : undefined}
     >
       <Image width="25" height="25" alt="Logo" src={tokenIcons[ticker]} />
@@ -90,6 +85,7 @@ function TokenBalance(props: TokenBalanceProps) {
         flexGrow="1"
         marginLeft="5px"
         fontFamily="Favorit"
+        lineHeight="1"
         cursor="pointer"
         onClick={handleClick}
       >
@@ -100,18 +96,13 @@ function TokenBalance(props: TokenBalanceProps) {
               : undefined
           }
         >
-          <Text
-            fontSize="1.1em"
-            lineHeight="1"
-            opacity={isZero ? "40%" : undefined}
-          >
+          <Text fontSize="1.1em" opacity={isZero ? "40%" : undefined}>
             {formattedAmount} {ticker}
           </Text>
         </Tooltip>
         <Box
-          color="white.40"
+          color="text.muted"
           fontSize="0.8em"
-          lineHeight="1"
           opacity={!usdPrice ? "40%" : undefined}
         >
           {formattedUsdPrice}
@@ -119,6 +110,11 @@ function TokenBalance(props: TokenBalanceProps) {
       </Flex>
       <Tooltip label="Deposit">
         <ArrowDownIcon
+          transition="color 0.3s ease"
+          color="text.secondary"
+          _hover={{
+            color: "text.muted",
+          }}
           width="calc(0.5 * var(--banner-height))"
           height="calc(0.5 * var(--banner-height))"
           cursor="pointer"
@@ -130,6 +126,11 @@ function TokenBalance(props: TokenBalanceProps) {
       </Tooltip>
       <Tooltip label="Withdraw">
         <ArrowUpIcon
+          transition="color 0.3s ease"
+          color="text.secondary"
+          _hover={{
+            color: "text.muted",
+          }}
           width="calc(0.5 * var(--banner-height))"
           height="calc(0.5 * var(--banner-height))"
           borderRadius="100px"
@@ -152,7 +153,6 @@ function DepositWithdrawButtons() {
         flexDirection="row"
         width="100%"
         minHeight="var(--banner-height)"
-        color="white.60"
         borderColor="border"
         borderTop="var(--border)"
         cursor="pointer"
@@ -162,13 +162,14 @@ function DepositWithdrawButtons() {
           justifyContent="center"
           flexGrow="1"
           gap="5px"
-          color="white.90"
-          borderColor="border"
+          color="text.primary"
           borderRight="var(--border)"
           _hover={{
             backgroundColor: "#000",
+            color: "text.muted",
           }}
           cursor="pointer"
+          // transition="color 0.3s ease"
           onClick={() => {
             if (!address) return
 
@@ -193,7 +194,7 @@ function DepositWithdrawButtons() {
           }}
         >
           <Text>Airdrop</Text>
-          <ArrowDownIcon />
+          <ArrowDownIcon transition="color 0.3s ease" />
         </Flex>
       </Flex>
     </Tooltip>
@@ -292,7 +293,7 @@ function RenegadeWalletPanel(props: RenegadeWalletPanelProps) {
           <Text
             marginTop="10px"
             padding="0 10% 0 10%"
-            color={address ? "white.50" : "white.40"}
+            color="text.secondary"
             fontSize="0.8em"
             fontWeight="100"
             textAlign="center"
@@ -327,25 +328,24 @@ function RenegadeWalletPanel(props: RenegadeWalletPanelProps) {
           borderColor="border"
           borderBottom="var(--border)"
         >
-          <Text>Renegade Wallet</Text>
+          <Text color="text.primary">Renegade Wallet</Text>
           <Flex
             position="absolute"
-            left="10px"
+            top="12px"
+            left="29px"
             alignItems="center"
-            justifyContent="center"
-            width="calc(0.6 * var(--banner-height))"
-            height="calc(0.6 * var(--banner-height))"
-            borderRadius="100px"
+            color="text.primary"
             _hover={{
-              background: "white.10",
+              color: "text.secondary",
             }}
             cursor="pointer"
+            transition="color 0.3s ease"
             onClick={props.toggleIsLocked}
           >
             {props.isLocked ? (
-              <LockIcon boxSize="11px" color="white.80" />
+              <LockIcon boxSize="11px" />
             ) : (
-              <UnlockIcon boxSize="11px" color="white.80" />
+              <UnlockIcon boxSize="11px" />
             )}
           </Flex>
         </Flex>
@@ -375,7 +375,7 @@ function HistorySection() {
           borderTop="var(--border)"
           borderBottom="var(--border)"
         >
-          <Text>Task History</Text>
+          <Text color="text.primary">Task History</Text>
         </Flex>
       </Tooltip>
       <SimpleBar

--- a/trade.renegade.fi/components/steppers/create-stepper/steps/default-step.tsx
+++ b/trade.renegade.fi/components/steppers/create-stepper/steps/default-step.tsx
@@ -67,14 +67,18 @@ export function DefaultStep() {
   return (
     <>
       <ModalBody>
-        <Flex justifyContent="center" flexDirection="column" gap="4">
-          <Text color="white.60" fontSize="0.9em">
+        <Flex
+          justifyContent="center"
+          flexDirection="column"
+          gap="4"
+          color="text.secondary"
+        >
+          <Text fontSize="0.9em">
             To trade on Renegade, we require a one-time signature to unlock and
             create your wallet.
           </Text>
           <Flex gap="2">
             <Checkbox
-              color="white.30"
               isChecked={rememberMe}
               onChange={(e) => setRememberMe(e.target.checked)}
               size="sm"
@@ -84,11 +88,9 @@ export function DefaultStep() {
               cursor="pointer"
               onClick={() => setRememberMe((prev) => !prev)}
             >
-              <Text color="white.60" fontSize="0.9em">
-                Remember Me
-              </Text>
+              <Text fontSize="0.9em">Remember Me</Text>
               <Tooltip label={REMEMBER_ME_TOOLTIP} placement="right">
-                <CircleHelp color="#999999" height="16" />
+                <CircleHelp height="16" />
               </Tooltip>
             </Flex>
           </Flex>
@@ -96,7 +98,7 @@ export function DefaultStep() {
             <Button
               width="100%"
               height={status === "pending" ? "56px" : "40px"}
-              color="white.90"
+              color="text.primary"
               fontWeight="800"
               transition="0.2s"
               isLoading={status === "pending"}
@@ -116,7 +118,6 @@ export function DefaultStep() {
               transition="0.2s"
             >
               <Button
-                color="white.50"
                 fontFamily="Favorit"
                 fontSize="1em"
                 fontWeight="400"

--- a/trade.renegade.fi/styles/animations.css
+++ b/trade.renegade.fi/styles/animations.css
@@ -38,7 +38,7 @@
     color: var(--price-report-fade-red);
   }
   100% {
-    color: var(--chakra-colors-white-80);
+    color: inherit;
   }
 }
 
@@ -47,7 +47,7 @@
     color: var(--price-report-fade-green);
   }
   100% {
-    color: var(--chakra-colors-white-80);
+    color: inherit;
   }
 }
 
@@ -78,9 +78,4 @@
   100% {
     transform: translateX(-33.333%);
   }
-}
-
-.wrapper:hover #slide {
-  transition: 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
-  bottom: 0;
 }

--- a/trade.renegade.fi/styles/globals.css
+++ b/trade.renegade.fi/styles/globals.css
@@ -93,6 +93,11 @@ body {
   user-select: none;
 }
 
+p {
+  will-change: color;
+  transition: color 0.3s ease;
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
This PR defines `text.primary`, `text.secondary`, and `text.muted` colors in the theme and applies these colors to text throughout the app. Also applies a global transition for `p` tags that change color on hover, along with icons.