### PR TITLE
trade: misc ui fixes

### DIFF
--- a/trade.renegade.fi/components/banners/tokens-banner.tsx
+++ b/trade.renegade.fi/components/banners/tokens-banner.tsx
@@ -37,9 +37,9 @@ export function TokensBanner({}: { prices?: number[] }) {
             color="text.primary"
             borderRadius="0.5rem"
             _hover={{
-              backgroundColor: "white.10",
               color: "text.primary",
             }}
+            cursor="pointer"
             transition="background-color 0.3s ease"
             onClick={() => setBaseToken(ticker)}
           >

--- a/trade.renegade.fi/components/panels/orders-panel.tsx
+++ b/trade.renegade.fi/components/panels/orders-panel.tsx
@@ -58,10 +58,20 @@ function SingleOrder({ order }: { order: OrderMetadata }) {
   const base = Token.findByAddress(base_mint)
   const quote = Token.findByAddress(quote_mint)
   const formattedAmount = formatNumber(amount, base.decimals)
+  const formattedAmountLong = formatNumber(amount, base.decimals, true)
   const formattedRemaining = formatNumber(
     BigInt(amount) - BigInt(filled),
     base.decimals
   )
+  const formattedRemainingLong = formatNumber(
+    BigInt(amount) - BigInt(filled),
+    base.decimals,
+    true
+  )
+  const amountLabel =
+    state === OrderState.Filled ? formattedAmount : formattedRemaining
+  const amountLabelLong =
+    state === OrderState.Filled ? formattedAmountLong : formattedRemainingLong
   const formattedState = getReadableState(state)
 
   const fillLabel = `${Math.round((Number(filled) / Number(amount)) * 100)}%`
@@ -69,6 +79,8 @@ function SingleOrder({ order }: { order: OrderMetadata }) {
   const isCancellable = [OrderState.Created, OrderState.Matching].includes(
     state
   )
+
+  const isColored = isCancellable || state === OrderState.SettlingMatch
 
   const taskHistory = useTaskHistory()
   const isQueue = taskHistory.find(
@@ -88,11 +100,13 @@ function SingleOrder({ order }: { order: OrderMetadata }) {
   return (
     <Tooltip
       placement="left"
+      paddingX={3}
+      paddingY={2.8}
       // @ts-ignore
       label={ORDER_TOOLTIP(
         base.ticker,
-        formattedRemaining,
-        formattedAmount,
+        formattedRemainingLong,
+        formattedAmountLong,
         fillLabel,
         side,
         Number(created) / 1000
@@ -113,9 +127,9 @@ function SingleOrder({ order }: { order: OrderMetadata }) {
         }}
         whiteSpace="nowrap"
         transition="filter 0.3s ease"
-        filter={isCancellable ? "inherit" : "grayscale(1)"}
+        filter={isColored ? "inherit" : "grayscale(1)"}
       >
-        <Text fontFamily="Favorit" fontSize="1.2em">
+        <Text fontFamily="Favorit" fontSize="1.3em">
           {formattedState}
         </Text>
         <Box position="relative" width="45px" height="40px">
@@ -136,15 +150,21 @@ function SingleOrder({ order }: { order: OrderMetadata }) {
           />
         </Box>
         <Flex alignItems="flex-start" flexDirection="column" lineHeight="1">
-          <Text fontFamily="Favorit" fontSize="1.4em">
-            {formattedAmount} {base.ticker}
-          </Text>
+          <Tooltip
+            placement="bottom"
+            label={`${amountLabelLong} ${base.ticker}`}
+          >
+            <Text fontFamily="Favorit" fontSize="1.4em">
+              {amountLabel} {base.ticker}
+            </Text>
+          </Tooltip>
           <Text>{side.toUpperCase()}</Text>
         </Flex>
         {isCancellable ? (
           <Tooltip label="Cancel Order">
             <Icon
               as={X}
+              boxSize="1.4em"
               color="text.secondary"
               cursor="pointer"
               _hover={{
@@ -307,7 +327,7 @@ function OrderBookPanel() {
                 minWidth="100%"
                 whiteSpace="nowrap"
               >
-                <Text fontSize="1.2em" _groupHover={{ color: textColor }}>
+                <Text fontSize="1.3em" _groupHover={{ color: textColor }}>
                   {status}&nbsp;
                 </Text>
                 <Text>{dayjs.unix(Number(timestamp)).fromNow()}</Text>

--- a/trade.renegade.fi/components/panels/task-item.tsx
+++ b/trade.renegade.fi/components/panels/task-item.tsx
@@ -57,7 +57,7 @@ export function TaskItem({
           minWidth="100%"
           whiteSpace="nowrap"
         >
-          <Text fontSize="1.2em">{name}</Text>
+          <Text fontSize="1.3em">{name}</Text>
           <Flex gap="1" verticalAlign="middle">
             <Box
               _groupHover={{ color: iconColor }}

--- a/trade.renegade.fi/components/tooltip.tsx
+++ b/trade.renegade.fi/components/tooltip.tsx
@@ -4,19 +4,31 @@ export function Tooltip({
   children,
   label,
   placement = "bottom",
+  padding,
+  paddingY,
+  paddingX,
 }: {
   children: React.ReactNode
   label?: string
   placement?: "top" | "bottom" | "left" | "right"
+  padding?: number
+  paddingY?: number
+  paddingX?: number
 }) {
   return (
     <ChakraTooltip
+      padding={padding}
       color="white.100"
       fontFamily="Favorit"
+      border="var(--secondary-border)"
+      boxSizing="border-box"
+      arrowShadowColor="#474554"
       backgroundColor="white.10"
-      //   backgroundColor="white"
+      closeOnScroll
       hasArrow
       label={label}
+      paddingX={paddingX}
+      paddingY={paddingY}
       placement={placement}
     >
       {children}

--- a/trade.renegade.fi/lib/tooltip-labels.tsx
+++ b/trade.renegade.fi/lib/tooltip-labels.tsx
@@ -32,7 +32,7 @@ export const ORDER_TOOLTIP = (
   createdAt: number
 ) => {
   return (
-    <Text fontFamily="Favorit Mono">
+    <Text fontFamily="Favorit Mono" whiteSpace="nowrap">
       Original Size: {originalAmount} {base}
       <br />
       Remaining Size: {currentAmount} {base}

--- a/trade.renegade.fi/lib/utils.ts
+++ b/trade.renegade.fi/lib/utils.ts
@@ -28,27 +28,22 @@ export const formatNumber = (
 ) => {
   const balanceValue = Number(formatUnits(balance, decimals))
   const tempNumeral = numeral(balanceValue)
-  if (balance === BigInt(260000000000)) {
-    console.log("formatnumber debug: ", {
-      balance,
-      decimals,
-      long,
-      balanceValue,
-      tempNumeral,
-    })
-  }
 
   if (balanceValue.toString().indexOf("e") !== -1) {
-    return formatScientificToDecimal(balanceValue)
+    if (long) {
+      return formatScientificToDecimal(balanceValue)
+    } else {
+      return tempNumeral.format("0[.]00e+0")
+    }
   }
 
   let formatStr = ""
   if (balanceValue > 10000000) {
     formatStr = long ? "0,0[.]00" : "0.00a"
   } else if (balanceValue > 1000000) {
-    formatStr = `0${long ? ".[00]" : ""}`
+    formatStr = long ? "0.[00]" : "0[.]00a"
   } else if (balanceValue > 10000) {
-    formatStr = `0[.]00${long ? "00" : ""}`
+    formatStr = long ? "0.[00]" : "0[.]00a"
   } else if (balanceValue > 100) {
     formatStr = `0[.]00${long ? "00" : ""}`
   } else if (balanceValue >= 1) {


### PR DESCRIPTION
This PR
- removes bg on hover in token banner, instead shows pointer cursor
- shows the remaining balance on orders in order panel, unless the order is filled in which it shows the original amount
- increases text size of status of task item state for consistency
- adds border to tooltips
- adds padding to order tooltip
- formats very small amounts and very large amounts with abbreviations (scientific notation, "m" for million, etc.)