### PR TITLE
trade: remove lock from panel header

### DIFF
--- a/trade.renegade.fi/components/panels/orders-panel.tsx
+++ b/trade.renegade.fi/components/panels/orders-panel.tsx
@@ -13,7 +13,7 @@ import {
   ORDER_TOOLTIP,
 } from "@/lib/tooltip-labels"
 import { formatNumber } from "@/lib/utils"
-import { Icon, LockIcon, UnlockIcon } from "@chakra-ui/icons"
+import { Icon } from "@chakra-ui/icons"
 import { Box, Flex, Image, Text } from "@chakra-ui/react"
 import {
   OrderMetadata,
@@ -198,11 +198,7 @@ function SingleOrder({
   )
 }
 
-interface OrdersPanelProps {
-  isLocked: boolean
-  toggleIsLocked: () => void
-}
-function OrdersPanel(props: OrdersPanelProps) {
+function OrdersPanel() {
   const balances = useBalances()
   const orderHistory = useOrderHistory({ sort: "desc" })
   const status = useStatus()
@@ -256,35 +252,15 @@ function OrdersPanel(props: OrdersPanelProps) {
   return (
     <>
       <Tooltip placement="left" label={ORDER_HISTORY_TOOLTIP}>
-        <Flex
-          position="relative"
-          alignItems="center"
-          justifyContent="center"
-          width="100%"
-          minHeight="var(--banner-height)"
+        <Box
+          display="grid"
+          height="var(--banner-height)"
+          color="text.primary"
           borderBottom="var(--border)"
+          placeContent="center"
         >
-          <Flex
-            position="absolute"
-            top="12px"
-            left="29px"
-            alignItems="center"
-            color="text.primary"
-            _hover={{
-              color: "text.secondary",
-            }}
-            cursor="pointer"
-            transition="color 0.3s ease"
-            onClick={props.toggleIsLocked}
-          >
-            {props.isLocked ? (
-              <LockIcon boxSize="11px" />
-            ) : (
-              <UnlockIcon boxSize="11px" />
-            )}
-          </Flex>
-          <Text color="text.primary">Orders</Text>
-        </Flex>
+          <Text>Orders</Text>
+        </Box>
       </Tooltip>
       {Content}
     </>
@@ -375,13 +351,7 @@ function CounterpartiesPanel() {
   )
 }
 
-interface OrdersAndCounterpartiesPanelExpandedProps {
-  isLocked: boolean
-  toggleIsLocked: () => void
-}
-function OrdersAndCounterpartiesPanelExpanded(
-  props: OrdersAndCounterpartiesPanelExpandedProps
-) {
+function OrdersAndCounterpartiesPanelExpanded() {
   return (
     <Flex
       flexDirection="column"
@@ -389,10 +359,7 @@ function OrdersAndCounterpartiesPanelExpanded(
       borderLeft="var(--border)"
       backdropFilter="blur(8px)"
     >
-      <OrdersPanel
-        isLocked={props.isLocked}
-        toggleIsLocked={props.toggleIsLocked}
-      />
+      <OrdersPanel />
       <OrderBookPanel />
       <CounterpartiesPanel />
     </Flex>
@@ -403,12 +370,7 @@ export function OrdersAndCounterpartiesPanel() {
   const { open } = useModalConnectKit()
   return (
     <Panel
-      panelExpanded={(isLocked, toggleIsLocked) => (
-        <OrdersAndCounterpartiesPanelExpanded
-          isLocked={isLocked}
-          toggleIsLocked={toggleIsLocked}
-        />
-      )}
+      panelExpanded={() => <OrdersAndCounterpartiesPanelExpanded />}
       panelCollapsedDisplayTexts={["Orders", "Counterparties"]}
       isOpenConnectKitModal={open}
       flipDirection={true}

--- a/trade.renegade.fi/components/panels/panels.tsx
+++ b/trade.renegade.fi/components/panels/panels.tsx
@@ -107,12 +107,9 @@ interface PanelState {
 export class Panel extends React.Component<PanelProps, PanelState> {
   constructor(props: PanelProps) {
     super(props)
-    const isLockedStorage = window.localStorage.getItem(
-      this.getLocalStorageKey()
-    )
     this.state = {
       isHovering: false,
-      isLocked: isLockedStorage === "true" || isLockedStorage === null,
+      isLocked: true,
       isOpenModalWhenLeft: false,
       isModalJustClosed: false,
     }

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -9,12 +9,7 @@ import {
 } from "@/lib/tooltip-labels"
 import { Direction } from "@/lib/types"
 import { formatNumber, fundList, fundWallet } from "@/lib/utils"
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  LockIcon,
-  UnlockIcon,
-} from "@chakra-ui/icons"
+import { ArrowDownIcon, ArrowUpIcon } from "@chakra-ui/icons"
 import { Box, Button, Flex, Spacer, Text } from "@chakra-ui/react"
 import {
   Token,
@@ -200,11 +195,7 @@ function DepositWithdrawButtons() {
   )
 }
 
-interface RenegadeWalletPanelProps {
-  isLocked: boolean
-  toggleIsLocked: () => void
-}
-function RenegadeWalletPanel(props: RenegadeWalletPanelProps) {
+function RenegadeWalletPanel() {
   const { address } = useAccountWagmi()
   const { setView } = useApp()
   const balances = useBalances()
@@ -318,36 +309,15 @@ function RenegadeWalletPanel(props: RenegadeWalletPanelProps) {
   return (
     <>
       <Tooltip placement="right" label={RENEGADE_ACCOUNT_TOOLTIP}>
-        <Flex
-          position="relative"
-          alignItems="center"
-          justifyContent="center"
-          width="100%"
-          minHeight="var(--banner-height)"
-          borderColor="border"
+        <Box
+          display="grid"
+          height="var(--banner-height)"
+          color="text.primary"
           borderBottom="var(--border)"
+          placeContent="center"
         >
-          <Text color="text.primary">Renegade Wallet</Text>
-          <Flex
-            position="absolute"
-            top="12px"
-            left="29px"
-            alignItems="center"
-            color="text.primary"
-            _hover={{
-              color: "text.secondary",
-            }}
-            cursor="pointer"
-            transition="color 0.3s ease"
-            onClick={props.toggleIsLocked}
-          >
-            {props.isLocked ? (
-              <LockIcon boxSize="11px" />
-            ) : (
-              <UnlockIcon boxSize="11px" />
-            )}
-          </Flex>
-        </Flex>
+          <Text>Renegade Wallet</Text>
+        </Box>
       </Tooltip>
       {Content}
     </>
@@ -390,11 +360,7 @@ function HistorySection() {
   )
 }
 
-interface WalletsPanelExpandedProps {
-  isLocked: boolean
-  toggleIsLocked: () => void
-}
-function WalletsPanelExpanded(props: WalletsPanelExpandedProps) {
+function WalletsPanelExpanded() {
   return (
     <Flex
       flexDirection="column"
@@ -402,10 +368,7 @@ function WalletsPanelExpanded(props: WalletsPanelExpandedProps) {
       borderRight="var(--border)"
       backdropFilter="blur(8px)"
     >
-      <RenegadeWalletPanel
-        isLocked={props.isLocked}
-        toggleIsLocked={props.toggleIsLocked}
-      />
+      <RenegadeWalletPanel />
       <HistorySection />
       <DepositWithdrawButtons />
     </Flex>
@@ -416,12 +379,7 @@ export function WalletsPanel() {
   const { open } = useModalConnectKit()
   return (
     <Panel
-      panelExpanded={(isLocked, toggleIsLocked) => (
-        <WalletsPanelExpanded
-          isLocked={isLocked}
-          toggleIsLocked={toggleIsLocked}
-        />
-      )}
+      panelExpanded={() => <WalletsPanelExpanded />}
       panelCollapsedDisplayTexts={["Renegade Wallet", "History"]}
       isOpenConnectKitModal={open}
       flipDirection={false}


### PR DESCRIPTION
This PR removes lock functionality from side panels, opting for always open panels instead.