### PR TITLE
trade: set side buy on USDC click in panel

### DIFF
--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -7,6 +7,7 @@ import {
   RENEGADE_ACCOUNT_TOOLTIP,
   TASK_HISTORY_TOOLTIP,
 } from "@/lib/tooltip-labels"
+import { Direction } from "@/lib/types"
 import { formatNumber, fundList, fundWallet } from "@/lib/utils"
 import {
   ArrowDownIcon,
@@ -49,7 +50,10 @@ interface TokenBalanceProps {
 function TokenBalance(props: TokenBalanceProps) {
   const { setView, tokenIcons } = useApp()
   const token = Token.findByAddress(props.tokenAddr)
-  const [_, setBase] = useLocalStorage("base", "WETH", {
+  const [, setBase] = useLocalStorage("base", "WETH", {
+    initializeWithValue: false,
+  })
+  const [, setDirection] = useLocalStorage("direction", Direction.BUY, {
     initializeWithValue: false,
   })
 
@@ -64,7 +68,11 @@ function TokenBalance(props: TokenBalanceProps) {
   const isZero = props.amount === BigInt(0)
 
   const handleClick = () => {
-    setBase(ticker)
+    if (ticker === "USDC") {
+      setDirection(Direction.BUY)
+    } else {
+      setBase(ticker)
+    }
     setView(ViewEnum.TRADING)
   }
   return (


### PR DESCRIPTION
This PR sets side to buy if USDC balance is clicked in the wallet panel.