### PR TITLE
trade: fund earlier in onboarding process

### DIFF
--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -171,26 +171,20 @@ function DepositWithdrawButtons() {
           cursor="pointer"
           // transition="color 0.3s ease"
           onClick={() => {
-            if (!address) return
+            if (!address) {
+              toast.error("Please connect your wallet to fund your account.")
+              return
+            }
 
-            toast.promise(
-              fundWallet(
-                [
-                  { ticker: "WETH", amount: "10" },
-                  { ticker: "USDC", amount: "1000000" },
-                ],
-                address
-              ),
-              {
-                loading: "Funding account...",
-                success: "Your account has been funded with test funds.",
-                error:
-                  "Funding failed: An unexpected error occurred. Please try again.",
-              }
-            )
+            toast.promise(fundWallet(fundList.slice(0, 2), address), {
+              loading: "Funding account...",
+              success: "Successfully funded account.",
+              error:
+                "Funding failed: An unexpected error occurred. Please try again.",
+            })
 
             // Fund additional wallets in background
-            fundWallet(fundList, address)
+            fundWallet(fundList.slice(2), address)
           }}
         >
           <Text>Airdrop</Text>

--- a/trade.renegade.fi/constants/storage-keys.ts
+++ b/trade.renegade.fi/constants/storage-keys.ts
@@ -1,0 +1,3 @@
+const STORAGE_PREFIX = "renegade."
+export const FUNDED_ADDRESSES = `${STORAGE_PREFIX}funded_addresses`
+export const REMEMBER_ME = `${STORAGE_PREFIX}remember_me`

--- a/trade.renegade.fi/lib/utils.ts
+++ b/trade.renegade.fi/lib/utils.ts
@@ -1,6 +1,8 @@
+import { FUNDED_ADDRESSES } from "@/constants/storage-keys"
 import { env } from "@/env.mjs"
 import { Metadata } from "next"
 import numeral from "numeral"
+import { Address } from "viem"
 import { formatUnits } from "viem/utils"
 
 export function safeLocalStorageGetItem(key: string): string | null {
@@ -144,38 +146,35 @@ export function constructMetadata({
 
 export const fundWallet = async (
   tokens: { ticker: string; amount: string }[],
-  address: `0x${string}`
+  address: Address
 ) => {
-  try {
-    const response = await fetch(`/api/fund`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        tokens,
-        address,
-      }),
-    })
+  const response = await fetch(`/api/fund`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      tokens,
+      address,
+    }),
+  })
 
-    if (!response.ok) {
-      const text = await response.text()
-      throw new Error(
-        text ||
-          "Funding failed: An unexpected error occurred. Please try again."
-      )
-    }
-
+  if (!response.ok) {
     const text = await response.text()
-    safeLocalStorageSetItem(`funded_${address}`, "true")
-    console.log("Funding success:", text)
-  } catch (error) {
-    console.error("Error:", error)
-    throw error
+    console.error("could not fund", text)
+  } else {
+    const fundedAddresses = JSON.parse(
+      safeLocalStorageGetItem(FUNDED_ADDRESSES) || "[]"
+    )
+    const updatedAddresses = Array.from(new Set([...fundedAddresses, address]))
+    safeLocalStorageSetItem(FUNDED_ADDRESSES, JSON.stringify(updatedAddresses))
+    console.log("Funding success")
   }
 }
 
 export const fundList: { ticker: string; amount: string }[] = [
+  { ticker: "WETH", amount: "10" },
+  { ticker: "USDC", amount: "1000000" },
   {
     ticker: "WBTC",
     amount: "5",


### PR DESCRIPTION
This PR ensures user wallets are funded earlier in the onboarding process, right after their wallet is connected. Also changes the funding script to fund up to a certain amount, so calling this script multiple times does not matter. Also attaches listener to wagmi account and disconnects Renegade accounts on wallet disconnect.