### PR TITLE
trade: show warning if insufficient usdc balance to fill order

### DIFF
--- a/trade.renegade.fi/app/(desktop)/trading.tsx
+++ b/trade.renegade.fi/app/(desktop)/trading.tsx
@@ -157,7 +157,7 @@ function TradingInner() {
             </Text>
             <Text variant="trading-body-button">{quote}</Text>
           </HStack>
-          <HelperText baseTicker={base} />
+          <HelperText base={Token.findByTicker(base)} />
         </Flex>
         <PlaceOrderButton
           baseTokenAmount={baseTokenAmount}
@@ -177,8 +177,8 @@ function TradingInner() {
   )
 }
 
-function HelperText({ baseTicker }: { baseTicker: string }) {
-  const usdPrice = useUSDPrice(baseTicker, 1)
+function HelperText({ base }: { base: Token }) {
+  const usdPrice = useUSDPrice(base)
   const formattedUsdPrice = numeral(usdPrice).format("$0.00")
   return (
     <Text color="text.muted" fontWeight="100" userSelect="text">
@@ -203,7 +203,7 @@ function InputWithMaxButton({
   })
   const [direction] = useLocalStorage("direction", Direction.BUY)
   const max = useMax(direction === Direction.SELL ? base : quote)
-  const usdPrice = useUSDPrice(base, 1)
+  const usdPrice = useUSDPrice(Token.findByTicker(base))
   const buyMax = (1 / usdPrice) * Number(max) * 0.99
 
   const handleSetBaseTokenAmount = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/trade.renegade.fi/app/providers.tsx
+++ b/trade.renegade.fi/app/providers.tsx
@@ -80,6 +80,7 @@ const styles = {
 const colors = {
   green: "#43e043",
   red: "#e04943",
+  yellow: "#fecb33",
   brown: "#231f20",
   "brown.light": "#372f2f",
   "white.100": "#ffffff",

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -17,7 +17,6 @@ import {
 import { Box, Button, Flex, Spacer, Text } from "@chakra-ui/react"
 import {
   Token,
-  formatAmount,
   tokenMapping,
   useBalances,
   useStatus,
@@ -55,10 +54,7 @@ function TokenBalance(props: TokenBalanceProps) {
 
   const formattedAmount = formatNumber(props.amount, token.decimals)
   const ticker = token.ticker
-  const usdPrice = useUSDPrice(
-    ticker,
-    parseFloat(formatAmount(props.amount, token))
-  )
+  const usdPrice = useUSDPrice(token, props.amount)
   const formattedUsdPrice = numeral(usdPrice).format("$0.00")
 
   const isZero = props.amount === BigInt(0)

--- a/trade.renegade.fi/components/place-order-button.tsx
+++ b/trade.renegade.fi/components/place-order-button.tsx
@@ -17,6 +17,7 @@ import { useMemo } from "react"
 import { toast } from "sonner"
 import { useLocalStorage } from "usehooks-ts"
 import { v4 as uuidv4 } from "uuid"
+import { parseUnits } from "viem/utils"
 import { useAccount as useAccountWagmi } from "wagmi"
 
 import { useButton } from "@/hooks/use-button"
@@ -116,7 +117,10 @@ export function PlaceOrderButton({
   }
 
   const isDisabled = isConnected && (!baseTokenAmount || hasZeroBalance)
-  const costInUsd = useUSDPrice(base, parseFloat(baseTokenAmount))
+  const costInUsd = useUSDPrice(
+    baseToken,
+    parseUnits(baseTokenAmount, baseToken.decimals)
+  )
 
   const hasInsufficientBalance = useMemo(() => {
     if (!baseTokenAmount) return false

--- a/trade.renegade.fi/hooks/use-usd-price.ts
+++ b/trade.renegade.fi/hooks/use-usd-price.ts
@@ -1,22 +1,26 @@
 import { usePrice } from "@/contexts/PriceContext/price-context"
 import { Token } from "@renegade-fi/react"
 import { useEffect, useState } from "react"
+import { formatUnits, parseUnits } from "viem/utils"
 
-export const useUSDPrice = (base: string, amount: number) => {
+// Returns USD price of the given amount of the base token
+export const useUSDPrice = (base: Token, amount?: bigint) => {
   const [price, setPrice] = useState(0)
 
   const { handleSubscribe, handleGetPrice } = usePrice()
-  const priceReport = handleGetPrice(
-    "binance",
-    Token.findByTicker(base).address
-  )
+  const priceReport = handleGetPrice("binance", base.address)
   useEffect(() => {
     if (!priceReport) return
     setPrice(priceReport)
   }, [priceReport])
   useEffect(() => {
-    handleSubscribe("binance", Token.findByTicker(base).address)
+    handleSubscribe("binance", base.address)
   }, [base, handleSubscribe])
 
-  return price * amount
+  return (
+    price *
+    parseFloat(
+      formatUnits(amount || parseUnits("1", base.decimals), base.decimals)
+    )
+  )
 }

--- a/trade.renegade.fi/lib/tooltip-labels.tsx
+++ b/trade.renegade.fi/lib/tooltip-labels.tsx
@@ -1,5 +1,6 @@
 import { Text } from "@chakra-ui/react"
 import dayjs from "dayjs"
+import { TriangleAlert } from "lucide-react"
 
 export const ORDER_HISTORY_TOOLTIP =
   "Your private orders. Only you and your connected relayer can see these values."
@@ -25,11 +26,14 @@ export const ACTIVE_ORDERS_TOOLTIP =
   "The total number of outstanding orders in Renegade."
 export const ORDER_TOOLTIP = (
   base: string,
+  quote: string,
   currentAmount: string,
   originalAmount: string,
   fill: string,
   side: string,
-  createdAt: number
+  createdAt: number,
+  usdValue: string,
+  insufficientBalance?: boolean
 ) => {
   return (
     <Text fontFamily="Favorit Mono" whiteSpace="nowrap">
@@ -38,10 +42,29 @@ export const ORDER_TOOLTIP = (
       Remaining Size: {currentAmount} {base}
       <br />
       Fill: {fill}
+      {usdValue ? (
+        <>
+          <br />
+          Value: {usdValue}
+        </>
+      ) : null}
       <br />
       Side: {side}
       <br />
       Created: {dayjs.unix(createdAt).fromNow()}
+      <br />
+      {insufficientBalance && (
+        <Text
+          as="span"
+          alignItems="center"
+          gap="2"
+          display="flex"
+          marginTop="8px"
+        >
+          <TriangleAlert size="14" color="#fecb33" /> Insufficient{" "}
+          {side === "Buy" ? quote : base} to fill order
+        </Text>
+      )}
     </Text>
   )
 }


### PR DESCRIPTION
This PR adds a warning to the order tooltip if the user does not have enough `send_balance` to fill the order.