### PR TITLE
trade: show nonzero balances on top

### DIFF
--- a/trade.renegade.fi/components/panels/empty-balance-item.tsx
+++ b/trade.renegade.fi/components/panels/empty-balance-item.tsx
@@ -1,0 +1,70 @@
+import { ViewEnum, useApp } from "@/contexts/App/app-context"
+import { MAX_BALANCES_TOOLTIP } from "@/lib/tooltip-labels"
+import { ArrowDownIcon, ArrowUpIcon } from "@chakra-ui/icons"
+import { Box, Circle, Flex } from "@chakra-ui/react"
+import "simplebar-react/dist/simplebar.min.css"
+
+import { Tooltip } from "../tooltip"
+
+export function EmptyBalanceItem() {
+  const { setView } = useApp()
+  return (
+    <Tooltip placement="right" label={MAX_BALANCES_TOOLTIP}>
+      <Flex
+        alignItems="center"
+        gap="5px"
+        width="100%"
+        minHeight="51px"
+        padding="5% 6%"
+        color="text.secondary"
+        borderBottom="var(--secondary-border)"
+        boxSizing="border-box"
+      >
+        <Circle opacity="40%" backgroundColor="text.muted" size="25px" />
+        <Flex
+          flexDirection="column"
+          flexGrow="1"
+          gap="1"
+          marginLeft="5px"
+          opacity="40%"
+        >
+          <Box width="48px" height="12px" backgroundColor="text.muted" />
+          <Box width="24px" height="6px" backgroundColor="text.muted" />
+        </Flex>
+        <Tooltip label="Deposit">
+          <ArrowDownIcon
+            opacity="40%"
+            transition="color 0.3s ease"
+            color="text.secondary"
+            _hover={{
+              color: "text.muted",
+            }}
+            width="calc(0.5 * var(--banner-height))"
+            height="calc(0.5 * var(--banner-height))"
+            cursor="pointer"
+            onClick={() => {
+              setView(ViewEnum.DEPOSIT)
+            }}
+          />
+        </Tooltip>
+        <Tooltip label="Withdraw">
+          <ArrowUpIcon
+            opacity="40%"
+            transition="color 0.3s ease"
+            color="text.secondary"
+            _hover={{
+              color: "text.muted",
+            }}
+            width="calc(0.5 * var(--banner-height))"
+            height="calc(0.5 * var(--banner-height))"
+            // borderRadius="100px"
+            cursor="pointer"
+            onClick={() => {
+              setView(ViewEnum.WITHDRAW)
+            }}
+          />
+        </Tooltip>
+      </Flex>
+    </Tooltip>
+  )
+}

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -216,28 +216,23 @@ function RenegadeWalletPanel(props: RenegadeWalletPanelProps) {
     status === "looking up" ||
     status === "connecting"
 
-  const formattedBalances = useMemo<Array<[Address, bigint]>>(() => {
+  const formattedBalances = useMemo(() => {
     const wethAddress = Token.findByTicker("WETH").address
     const usdcAddress = Token.findByTicker("USDC").address
 
-    const nonzero: Array<[Address, bigint]> = Object.entries(balances).map(
-      ([_, b]) => [b.mint, b.amount]
-    )
-    const placeholders: Array<[Address, bigint]> = tokenMapping.tokens
-      .filter((t) => !nonzero.some(([a]) => a === t.address))
-      .map((t) => [t.address as Address, BigInt(0)])
-
-    const combined = [...nonzero, ...placeholders]
-
-    combined.sort((a, b) => {
-      if (a[0] === wethAddress) return -1
-      if (b[0] === wethAddress) return 1
-      if (a[0] === usdcAddress) return -1
-      if (b[0] === usdcAddress) return 1
+    balances.sort((a, b) => {
+      if (a.mint === wethAddress) return -1
+      if (b.mint === wethAddress) return 1
+      if (a.mint === usdcAddress) return -1
+      if (b.mint === usdcAddress) return 1
       return 0
     })
 
-    return combined
+    const placeholders = tokenMapping.tokens
+      .filter((t) => !balances.some((b) => b.mint === t.address))
+      .map((t) => ({ mint: t.address as Address, amount: BigInt(0) }))
+
+    return [...balances, ...placeholders]
   }, [balances])
 
   const Content = useMemo(() => {
@@ -251,9 +246,12 @@ function RenegadeWalletPanel(props: RenegadeWalletPanelProps) {
               padding: "0 8px",
             }}
           >
-            {formattedBalances.map(([address, amount]) => (
-              <Box key={address} width="100%">
-                <TokenBalance tokenAddr={address} amount={amount} />
+            {formattedBalances.map((balance) => (
+              <Box key={balance.mint} width="100%">
+                <TokenBalance
+                  tokenAddr={balance.mint}
+                  amount={balance.amount}
+                />
               </Box>
             ))}
           </SimpleBar>

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -14,7 +14,17 @@ import {
   LockIcon,
   UnlockIcon,
 } from "@chakra-ui/icons"
-import { Box, Button, Flex, Spacer, Text } from "@chakra-ui/react"
+import {
+  Box,
+  Button,
+  Circle,
+  Flex,
+  Skeleton,
+  SkeletonCircle,
+  SkeletonText,
+  Spacer,
+  Text,
+} from "@chakra-ui/react"
 import {
   Token,
   formatAmount,
@@ -36,6 +46,7 @@ import { useAccount as useAccountWagmi } from "wagmi"
 
 import { useUSDPrice } from "@/hooks/use-usd-price"
 
+import { EmptyBalanceItem } from "@/components/panels/empty-balance-item"
 import { Panel, expandedPanelWidth } from "@/components/panels/panels"
 import { TaskHistoryList } from "@/components/panels/task-history-list"
 
@@ -228,9 +239,10 @@ function RenegadeWalletPanel(props: RenegadeWalletPanelProps) {
       return 0
     })
 
-    const placeholders = tokenMapping.tokens
-      .filter((t) => !balances.some((b) => b.mint === t.address))
-      .map((t) => ({ mint: t.address as Address, amount: BigInt(0) }))
+    const placeholders = Array.from({ length: 5 - balances.length }, () => ({
+      mint: "" as Address,
+      amount: BigInt(0),
+    }))
 
     return [...balances, ...placeholders]
   }, [balances])
@@ -246,14 +258,16 @@ function RenegadeWalletPanel(props: RenegadeWalletPanelProps) {
               padding: "0 8px",
             }}
           >
-            {formattedBalances.map((balance) => (
-              <Box key={balance.mint} width="100%">
+            {formattedBalances.map((balance) => {
+              if (!balance.mint) return <EmptyBalanceItem />
+              return (
                 <TokenBalance
+                  key={balance.mint}
                   tokenAddr={balance.mint}
                   amount={balance.amount}
                 />
-              </Box>
-            ))}
+              )
+            })}
           </SimpleBar>
           <Spacer />
         </>

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -14,21 +14,10 @@ import {
   LockIcon,
   UnlockIcon,
 } from "@chakra-ui/icons"
-import {
-  Box,
-  Button,
-  Circle,
-  Flex,
-  Skeleton,
-  SkeletonCircle,
-  SkeletonText,
-  Spacer,
-  Text,
-} from "@chakra-ui/react"
+import { Box, Button, Flex, Spacer, Text } from "@chakra-ui/react"
 import {
   Token,
   formatAmount,
-  tokenMapping,
   useBalances,
   useStatus,
   useTaskHistory,

--- a/trade.renegade.fi/lib/tooltip-labels.tsx
+++ b/trade.renegade.fi/lib/tooltip-labels.tsx
@@ -49,3 +49,5 @@ export const REMEMBER_ME_TOOLTIP =
   "Only use this option if you are using a secure device that you own."
 export const INSUFFICIENT_BALANCE_TOOLTIP =
   "Insufficient balance to cover the entire order. Only part of the order will be filled."
+export const MAX_BALANCES_TOOLTIP =
+  "Renegade wallets can hold up to 5 balances at a time."


### PR DESCRIPTION
This PR ensures nonzero balances are always shown at the top of the balances section of the wallet panel.

Experimental: show empty balance placeholder if < `MAX_BALANCES` balances