### PR TITLE
trade: bump sdk

### DIFF
--- a/trade.renegade.fi/package.json
+++ b/trade.renegade.fi/package.json
@@ -22,7 +22,7 @@
     "@datadog/browser-rum": "^5.15.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@renegade-fi/react": "^0.0.25",
+    "@renegade-fi/react": "^0.0.26",
     "@t3-oss/env-nextjs": "^0.6.0",
     "@tanstack/react-query": "^5.24.1",
     "@vercel/analytics": "^1.2.2",

--- a/trade.renegade.fi/pnpm-lock.yaml
+++ b/trade.renegade.fi/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^11.11.0
     version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.2.77)(react@18.2.0)
   '@renegade-fi/react':
-    specifier: ^0.0.25
-    version: 0.0.25(@types/react@18.2.77)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4)
+    specifier: ^0.0.26
+    version: 0.0.26(@types/react@18.2.77)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4)
   '@t3-oss/env-nextjs':
     specifier: ^0.6.0
     version: 0.6.1(typescript@5.1.6)(zod@3.22.4)
@@ -4267,8 +4267,8 @@ packages:
       react-native: 0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4)(react@18.2.0)
     dev: false
 
-  /@renegade-fi/core@0.0.25(@types/react@18.2.77)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4):
-    resolution: {integrity: sha512-6TQkC6EQVeWsHyinrcn+3Bo7P/pyjuyeSPZbA+7cseRfOO92eHDTciygg4x+dK4PVvNr9pAm2Gqco9JOX7v3hA==}
+  /@renegade-fi/core@0.0.26(@types/react@18.2.77)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4):
+    resolution: {integrity: sha512-LcEcIk4vetPwIKawk7plaxSLsJr9Ax4xBNu0h1Ru6938tuodA3yB2CPx1/HQRpf1DSxZHw9QlaDhTMWgHWIF/w==}
     dependencies:
       axios: 1.7.1
       isomorphic-ws: 5.0.0(ws@8.13.0)
@@ -4288,12 +4288,12 @@ packages:
       - zod
     dev: false
 
-  /@renegade-fi/react@0.0.25(@types/react@18.2.77)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4):
-    resolution: {integrity: sha512-okBKRN9DrKVhPJQyIWMs38GyLqYxBeUJbg/mhVWI9uwa4aOActzzIIbc9K1AJfYCDX+/c8VtMtwLWHjmeHa76w==}
+  /@renegade-fi/react@0.0.26(@types/react@18.2.77)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4):
+    resolution: {integrity: sha512-6GbAj4dLwfOLIsoLxzbwRZC9gXsPnBEfM1FED/CTu5jVEilttAkuc+iAWdXrLF/B7aYFOMKgqnjqTq5cR0uEWw==}
     peerDependencies:
       react: '>=18'
     dependencies:
-      '@renegade-fi/core': 0.0.25(@types/react@18.2.77)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4)
+      '@renegade-fi/core': 0.0.26(@types/react@18.2.77)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0)(zod@3.22.4)
       json-bigint: 1.0.0
       react: 18.2.0
       react-use-websocket: 4.8.1(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
This PR bumps the SDK version to `0.0.26` which prevents deposits from being submitted if it would result in more than `MAX_BALANCES` balances.