### PR TITLE
trade: display long number format in token select modal

### DIFF
--- a/trade.renegade.fi/components/modals/erc20-token-select-modal.tsx
+++ b/trade.renegade.fi/components/modals/erc20-token-select-modal.tsx
@@ -67,7 +67,11 @@ export function ERC20TokenSelectModal({
       .sort((a, b) => Number(b.balance - a.balance)) // Sort in descending order
       .map(({ address, balance }) => ({
         address,
-        balance: formatNumber(balance, Token.findByAddress(address).decimals),
+        balance: formatNumber(
+          balance,
+          Token.findByAddress(address).decimals,
+          true
+        ),
       }))
   }, [balances, debouncedSearchTerm])
 

--- a/trade.renegade.fi/components/modals/renegade-token-select-modal.tsx
+++ b/trade.renegade.fi/components/modals/renegade-token-select-modal.tsx
@@ -47,7 +47,11 @@ export function TradingTokenSelectModal({
       .sort((a, b) => Number(b.balance - a.balance)) // Sort in descending order
       .map(({ address, balance }) => ({
         address,
-        balance: formatNumber(balance, Token.findByAddress(address).decimals),
+        balance: formatNumber(
+          balance,
+          Token.findByAddress(address).decimals,
+          true
+        ),
       }))
   }, [balances, debouncedSearchTerm, tokens])
 


### PR DESCRIPTION
This PR modifies the token select modals to display long balances that are more accurate.