### PR TITLE
trade: use react-query for data fetching

### DIFF
--- a/trade.renegade.fi/app/(desktop)/deposit-button.tsx
+++ b/trade.renegade.fi/app/(desktop)/deposit-button.tsx
@@ -100,8 +100,8 @@ export default function DepositButton({
 
   // Deposit
   const config = useConfig()
-  const taskHistory = useTaskHistory()
-  const isQueue = taskHistory.find(
+  const { data: taskHistory } = useTaskHistory()
+  const isQueue = Array.from(taskHistory?.values() || []).find(
     (task) => task.state !== "Completed" && task.state !== "Failed"
   )
   const handleSignAndDeposit = async () => {

--- a/trade.renegade.fi/app/(desktop)/place-order-button.tsx
+++ b/trade.renegade.fi/app/(desktop)/place-order-button.tsx
@@ -63,8 +63,8 @@ export function PlaceOrderButton({
 
   const isConnected = status === "in relayer"
 
-  const taskHistory = useTaskHistory()
-  const isQueue = taskHistory.find(
+  const { data: taskHistory } = useTaskHistory()
+  const isQueue = Array.from(taskHistory?.values() || []).find(
     (task) => task.state !== "Completed" && task.state !== "Failed"
   )
   const handlePlaceOrder = async () => {

--- a/trade.renegade.fi/app/(desktop)/withdraw-button.tsx
+++ b/trade.renegade.fi/app/(desktop)/withdraw-button.tsx
@@ -61,8 +61,8 @@ export default function WithdrawButton({
   const { address } = useAccount()
 
   const fees = useFees()
-  const taskHistory = useTaskHistory()
-  const isQueue = taskHistory.find(
+  const { data: taskHistory } = useTaskHistory()
+  const isQueue = Array.from(taskHistory?.values() || []).find(
     (task) => task.state !== "Completed" && task.state !== "Failed"
   )
 

--- a/trade.renegade.fi/app/order-toaster.tsx
+++ b/trade.renegade.fi/app/order-toaster.tsx
@@ -3,26 +3,19 @@ import {
   OrderMetadata,
   OrderState,
   Token,
-  useOrderHistory,
   useOrderHistoryWebSocket,
-  useOrders,
 } from "@renegade-fi/react"
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 
 export function OrderToaster() {
-  const orderHistory = useOrderHistory()
-  const incomingOrder = useOrderHistoryWebSocket()
-  const orders = useOrders()
+  const [incomingOrder, setIncomingOrder] = useState<OrderMetadata>()
+  useOrderHistoryWebSocket({
+    onUpdate: (order) => {
+      setIncomingOrder(order)
+    },
+  })
   const orderMetadataRef = useRef<Map<string, OrderMetadata>>(new Map())
-
-  // Hydrate initial task history
-  useEffect(() => {
-    orderHistory.forEach((order) => {
-      if (orderMetadataRef.current.get(order.id)) return
-      orderMetadataRef.current.set(order.id, order)
-    })
-  }, [orderHistory])
 
   useEffect(() => {
     if (incomingOrder) {
@@ -60,7 +53,7 @@ export function OrderToaster() {
         )
       }
     }
-  }, [incomingOrder, orders])
+  }, [incomingOrder])
 
   return null
 }

--- a/trade.renegade.fi/app/providers.tsx
+++ b/trade.renegade.fi/app/providers.tsx
@@ -21,7 +21,9 @@ import {
   createConfig as createSDKConfig,
   useStatus,
 } from "@renegade-fi/react"
+import { focusManager } from "@tanstack/react-query"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { ConnectKitProvider, getDefaultConfig } from "connectkit"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
@@ -223,7 +225,13 @@ export const wagmiConfig = createConfig(
   })
 )
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchInterval: renegadeConfig.pollingInterval,
+    },
+  },
+})
 
 export function Providers({
   children,
@@ -245,6 +253,35 @@ export function Providers({
       window.removeEventListener("beforeunload", handleBeforeUnload)
     }
   }, [rememberMe])
+
+  // Invalidate query cache when the window loses focus
+  useEffect(() => {
+    focusManager.setEventListener((handleFocus) => {
+      if (typeof window !== "undefined" && window.addEventListener) {
+        const visibilitychangeHandler = () => {
+          handleFocus(document.visibilityState === "visible")
+        }
+        const focusHandler = () => {
+          handleFocus(document.hasFocus())
+        }
+        window.addEventListener(
+          "visibilitychange",
+          visibilitychangeHandler,
+          false
+        )
+        window.addEventListener("focus", focusHandler, false)
+        window.addEventListener("blur", focusHandler, false)
+        return () => {
+          window.removeEventListener(
+            "visibilitychange",
+            visibilitychangeHandler
+          )
+          window.removeEventListener("focus", focusHandler)
+          window.removeEventListener("blur", focusHandler)
+        }
+      }
+    })
+  }, [])
 
   return (
     <>
@@ -269,6 +306,7 @@ export function Providers({
                       <OrderToaster />
                       {children}
                       <LazyDatadog />
+                      <ReactQueryDevtools initialIsOpen={false} />
                     </ConnectKitProviderWithSignMessage>
                   </AppProvider>
                 </QueryClientProvider>

--- a/trade.renegade.fi/app/task-toaster.tsx
+++ b/trade.renegade.fi/app/task-toaster.tsx
@@ -3,27 +3,18 @@ import {
   generateFailedToastMessage,
   generateStartToastMessage,
 } from "@/lib/task"
-import {
-  Task,
-  TaskType,
-  useTaskHistory,
-  useTaskHistoryWebSocket,
-} from "@renegade-fi/react"
-import { useEffect, useRef } from "react"
+import { Task, TaskType, useTaskHistoryWebSocket } from "@renegade-fi/react"
+import { useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 
 export function TaskToaster() {
-  const incomingTask = useTaskHistoryWebSocket()
-  const taskHistory = useTaskHistory()
+  const [incomingTask, setIncomingTask] = useState<Task>()
+  useTaskHistoryWebSocket({
+    onUpdate(task) {
+      setIncomingTask(task)
+    },
+  })
   const taskRef = useRef<Map<string, Task>>(new Map())
-
-  // Hydrate initial task history
-  useEffect(() => {
-    taskHistory.forEach((task) => {
-      if (taskRef.current.get(task.id)) return
-      taskRef.current.set(task.id, task)
-    })
-  }, [taskHistory])
 
   useEffect(() => {
     if (incomingTask) {

--- a/trade.renegade.fi/components/panels/task-history-list.tsx
+++ b/trade.renegade.fi/components/panels/task-history-list.tsx
@@ -10,7 +10,10 @@ import {
 import { TaskItem } from "@/components/panels/task-item"
 
 export function TaskHistoryList() {
-  const history = useTaskHistory({ sort: "desc" })
+  const { data } = useTaskHistory()
+  const taskHistory = Array.from(data?.values() || []).sort((a, b) => {
+    return Number(b.created_at) - Number(a.created_at)
+  })
   const formattedTaskType = {
     [TaskType.NewWallet]: "New Wallet",
     [TaskType.UpdateWallet]: "Update Wallet",
@@ -37,7 +40,7 @@ export function TaskHistoryList() {
   }
   return (
     <>
-      {history.map((task) => {
+      {taskHistory.map((task) => {
         const createdAt = Number(task.created_at) / 1000
         const formattedState = formattedStates[task.state]
         switch (task.task_info.task_type) {

--- a/trade.renegade.fi/components/panels/user-order.tsx
+++ b/trade.renegade.fi/components/panels/user-order.tsx
@@ -7,7 +7,13 @@ import dayjs from "dayjs"
 
 import { Tooltip } from "@/components/tooltip"
 
-export function UserOrder({ order }: { order: OrderMetadata }) {
+export function UserOrder({
+  order,
+  timestamp,
+}: {
+  order: OrderMetadata
+  timestamp: bigint
+}) {
   const base = Token.findByAddress(order.data.base_mint)
   const quote = Token.findByAddress(order.data.quote_mint).ticker
   const formattedAmount = formatNumber(order.data.amount, base.decimals)
@@ -35,7 +41,7 @@ export function UserOrder({ order }: { order: OrderMetadata }) {
           <Text color={textColor} fontSize="1.2em">
             {getReadableState(order.state)}&nbsp;
           </Text>
-          <Text>{dayjs.unix(Number(order.created) / 1000).fromNow()}</Text>
+          <Text>{dayjs.unix(Number(timestamp)).fromNow()}</Text>
         </Flex>
         <Text>
           <Text as="span">{order.data.side}</Text>&nbsp;

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -318,12 +318,14 @@ function RenegadeWalletPanel() {
 }
 
 function HistorySection() {
-  const history = useTaskHistory()
-  const historyWithoutNewWallet = history.filter(
+  const status = useStatus()
+  const { data } = useTaskHistory()
+  const taskHistory = Array.from(data?.values() || []).filter(
     (task) => task.task_info.task_type !== "NewWallet"
   )
   const balances = useBalances()
-  if (!historyWithoutNewWallet.length && !balances.length) return null
+  if (status !== "in relayer") return null
+  if (!taskHistory.length && !balances.length) return null
   return (
     <>
       <Tooltip placement="right" label={TASK_HISTORY_TOOLTIP}>

--- a/trade.renegade.fi/package.json
+++ b/trade.renegade.fi/package.json
@@ -22,7 +22,7 @@
     "@datadog/browser-rum": "^5.15.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@renegade-fi/react": "^0.0.30",
+    "@renegade-fi/react": "0.0.31",
     "@t3-oss/env-nextjs": "^0.6.0",
     "@tanstack/react-query": "^5.24.1",
     "@vercel/analytics": "^1.2.2",
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^13.4.19",
+    "@tanstack/react-query-devtools": "^5.37.1",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/node": "20.4.2",
     "@types/numeral": "^2.0.5",

--- a/trade.renegade.fi/pnpm-lock.yaml
+++ b/trade.renegade.fi/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^11.11.0
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.2.77)(react@18.2.0))(@types/react@18.2.77)(react@18.2.0)
       '@renegade-fi/react':
-        specifier: ^0.0.30
-        version: 0.0.30(@types/react@18.2.77)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)
+        specifier: 0.0.31
+        version: 0.0.31(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)
       '@t3-oss/env-nextjs':
         specifier: ^0.6.0
         version: 0.6.1(typescript@5.1.6)(zod@3.22.4)
@@ -96,6 +96,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: ^13.4.19
         version: 13.5.6(bufferutil@4.0.8)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.37.1
+        version: 5.40.0(@tanstack/react-query@5.29.2(react@18.2.0))(react@18.2.0)
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
         version: 4.3.0(prettier@2.8.8)
@@ -2078,12 +2081,18 @@ packages:
     peerDependencies:
       react-native: '*'
 
-  '@renegade-fi/core@0.0.30':
-    resolution: {integrity: sha512-zlBipMI/GxYl8nqatLoAOs0R0pV+4jyWKl27GB82mtHUqreCcmLC44SmD6uUtlMc/ZIQ40zlp3uehPPTGQnp0w==}
-
-  '@renegade-fi/react@0.0.30':
-    resolution: {integrity: sha512-e5ziwjhtG5Q6RfZg68kDVRHHag1eaX61NMpUKf7kaHKLrkwwc5sfAJlqcM24LchuKTfSHah4gkWk+uNn4vSXUQ==}
+  '@renegade-fi/core@0.0.31':
+    resolution: {integrity: sha512-HpeUp8o3++XP8gLSA9U+HQrWEs3Dj9gq6b0dDvYWjn/MaMn8SnhmQDwh/KCUqNLCjJBKmrmZ3LALhqqNVTW+bA==}
     peerDependencies:
+      '@tanstack/query-core': '>=5.0.0'
+    peerDependenciesMeta:
+      '@tanstack/query-core':
+        optional: true
+
+  '@renegade-fi/react@0.0.31':
+    resolution: {integrity: sha512-EBRL2rb/5FTDqNrtO4YtxSWpJrvyQE4Hbxtib+Bh9R17rOSflmpvR5bRPRSwQNDWs2rQejupAAZhTH+wQ00glw==}
+    peerDependencies:
+      '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
 
   '@rushstack/eslint-patch@1.10.2':
@@ -2209,6 +2218,15 @@ packages:
 
   '@tanstack/query-core@5.29.0':
     resolution: {integrity: sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==}
+
+  '@tanstack/query-devtools@5.37.1':
+    resolution: {integrity: sha512-XcG4IIHIv0YQKrexTqo2zogQWR1Sz672tX2KsfE9kzB+9zhx44vRKH5si4WDILE1PIWQpStFs/NnrDQrBAUQpg==}
+
+  '@tanstack/react-query-devtools@5.40.0':
+    resolution: {integrity: sha512-JoQOQj/LKaHoHVMAh73R0pc4lIAHiZMV8L4DGHsTSvHcKi22LZmSC9aYBY9oMkqGpFtKmbspwrUIn55+czNSbA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.40.0
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.29.2':
     resolution: {integrity: sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==}
@@ -8677,7 +8695,7 @@ snapshots:
       nullthrows: 1.1.1
       react-native: 0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(react@18.2.0)
 
-  '@renegade-fi/core@0.0.30(@types/react@18.2.77)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)':
+  '@renegade-fi/core@0.0.31(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)':
     dependencies:
       axios: 1.7.2
       isomorphic-ws: 5.0.0(ws@8.13.0(bufferutil@4.0.8))
@@ -8685,6 +8703,8 @@ snapshots:
       tiny-invariant: 1.3.3
       viem: 2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4)
       zustand: 4.5.2(@types/react@18.2.77)(react@18.2.0)
+    optionalDependencies:
+      '@tanstack/query-core': 5.29.0
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -8696,14 +8716,16 @@ snapshots:
       - ws
       - zod
 
-  '@renegade-fi/react@0.0.30(@types/react@18.2.77)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)':
+  '@renegade-fi/react@0.0.31(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)':
     dependencies:
-      '@renegade-fi/core': 0.0.30(@types/react@18.2.77)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)
+      '@renegade-fi/core': 0.0.31(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)
+      '@tanstack/react-query': 5.29.2(react@18.2.0)
       json-bigint: 1.0.0
       react: 18.2.0
       react-use-websocket: 4.8.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
+      - '@tanstack/query-core'
       - '@types/react'
       - bufferutil
       - debug
@@ -8881,6 +8903,14 @@ snapshots:
       zod: 3.22.4
 
   '@tanstack/query-core@5.29.0': {}
+
+  '@tanstack/query-devtools@5.37.1': {}
+
+  '@tanstack/react-query-devtools@5.40.0(@tanstack/react-query@5.29.2(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/query-devtools': 5.37.1
+      '@tanstack/react-query': 5.29.2(react@18.2.0)
+      react: 18.2.0
 
   '@tanstack/react-query@5.29.2(react@18.2.0)':
     dependencies:


### PR DESCRIPTION
This PR upgrades the SDK which contains the refactor to using `react-query` for getter functions under the hood.

Related to: https://github.com/renegade-fi/sdk/pull/30