### PR TITLE
trade: use zustand for price reporter state management

### DIFF
--- a/trade.renegade.fi/app/(desktop)/layout.tsx
+++ b/trade.renegade.fi/app/(desktop)/layout.tsx
@@ -1,8 +1,9 @@
 import { Footer } from "@/app/(desktop)/footer"
 import { MainNav } from "@/app/(desktop)/main-nav"
 import { Providers } from "@/app/providers"
+import { PriceStoreProvider } from "@/contexts/price-context"
 import { TICKER_TO_LOGO_URL_HANDLE } from "@/lib/tokens"
-import { constructMetadata } from "@/lib/utils"
+import { constructMetadata, getInitialPrices } from "@/lib/utils"
 import "@/styles/animations.css"
 import "@/styles/fonts.css"
 import "@/styles/globals.css"
@@ -20,25 +21,27 @@ export default async function RootLayout({
   children: React.ReactNode
 }) {
   const icons = await TICKER_TO_LOGO_URL_HANDLE
-  // const prices = await getTokenBannerData(renegade)
+  const prices = await getInitialPrices()
   return (
     <html lang="en">
       <body>
-        <Providers icons={icons}>
-          <div
-            style={{
-              flexDirection: "column",
-              display: "flex",
-              minHeight: "100vh",
-              overflow: "hidden",
-            }}
-          >
-            <MainNav />
-            {children}
-            <TokensBanner />
-            <Footer />
-          </div>
-        </Providers>
+        <PriceStoreProvider initialPrices={prices}>
+          <Providers icons={icons}>
+            <div
+              style={{
+                flexDirection: "column",
+                display: "flex",
+                minHeight: "100vh",
+                overflow: "hidden",
+              }}
+            >
+              <MainNav />
+              {children}
+              <TokensBanner />
+              <Footer />
+            </div>
+          </Providers>
+        </PriceStoreProvider>
         <Analytics />
       </body>
     </html>

--- a/trade.renegade.fi/app/(desktop)/trading.tsx
+++ b/trade.renegade.fi/app/(desktop)/trading.tsx
@@ -2,6 +2,7 @@
 
 import { PlaceOrderButton } from "@/app/(desktop)/place-order-button"
 import { ViewEnum, useApp } from "@/contexts/App/app-context"
+import { usePrice } from "@/contexts/price-context"
 import { Direction } from "@/lib/types"
 import { ChevronDownIcon } from "@chakra-ui/icons"
 import {
@@ -174,8 +175,8 @@ export function TradingBody() {
 }
 
 function HelperText({ base }: { base: Token }) {
-  const usdPrice = useUSDPrice(base)
-  const formattedUsdPrice = numeral(usdPrice).format("$0.00")
+  const price = usePrice({ baseAddress: base.address })
+  const formattedUsdPrice = numeral(price).format("$0.00")
   return (
     <Text color="text.muted" fontWeight="100" userSelect="text">
       Trades are end-to-end encrypted and always clear at the real-time midpoint

--- a/trade.renegade.fi/app/providers.tsx
+++ b/trade.renegade.fi/app/providers.tsx
@@ -4,7 +4,6 @@ import LazyDatadog from "@/app/(desktop)/telemetry"
 import { OrderToaster } from "@/app/order-toaster"
 import { TaskToaster } from "@/app/task-toaster"
 import { AppProvider } from "@/contexts/App/app-context"
-import PriceProvider from "@/contexts/PriceContext/price-context"
 import { menuAnatomy } from "@chakra-ui/anatomy"
 import { CacheProvider } from "@chakra-ui/next-js"
 import {
@@ -265,13 +264,11 @@ export function Providers({
                 <QueryClientProvider client={queryClient}>
                   <AppProvider tokenIcons={icons}>
                     <ConnectKitProviderWithSignMessage>
-                      <PriceProvider>
-                        <Toaster position="bottom-center" richColors />
-                        <TaskToaster />
-                        <OrderToaster />
-                        {children}
-                        <LazyDatadog />
-                      </PriceProvider>
+                      <Toaster position="bottom-center" richColors />
+                      <TaskToaster />
+                      <OrderToaster />
+                      {children}
+                      <LazyDatadog />
                     </ConnectKitProviderWithSignMessage>
                   </AppProvider>
                 </QueryClientProvider>

--- a/trade.renegade.fi/components/live-price.tsx
+++ b/trade.renegade.fi/components/live-price.tsx
@@ -1,4 +1,5 @@
 import { BannerSeparator } from "./banner-separator"
+import { usePrice } from "@/contexts/price-context"
 import { TICKER_TO_DEFAULT_DECIMALS } from "@/lib/tokens"
 import { TriangleDownIcon, TriangleUpIcon } from "@chakra-ui/icons"
 import { Box, Flex, Text } from "@chakra-ui/react"
@@ -6,7 +7,6 @@ import { type Exchange, Token } from "@renegade-fi/react"
 import { useMemo } from "react"
 
 import { usePrevious } from "@/hooks/use-previous"
-import { usePrice } from "@/hooks/use-price"
 
 interface LivePricesProps {
   baseTicker: string
@@ -42,8 +42,10 @@ export const LivePrices = ({
       return Math.abs(baseDefaultDecimals) + 2
     }
   }, [baseDefaultDecimals, baseTicker, quoteTicker])
-
-  const price = usePrice(exchange, Token.findByTicker(baseTicker).address)
+  const price = usePrice({
+    exchange,
+    baseAddress: Token.findByTicker(baseTicker).address,
+  })
   const prevPrice = usePrevious(price)
 
   // Given the previous and current price reports, determine the displayed

--- a/trade.renegade.fi/contexts/price-context.tsx
+++ b/trade.renegade.fi/contexts/price-context.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+import { TICKER_TO_DEFAULT_DECIMALS } from "@/lib/tokens"
+import { Exchange, Token, tokenMapping } from "@renegade-fi/react"
+import {
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react"
+import useWebSocket, { ReadyState } from "react-use-websocket"
+import { StoreApi, createStore, useStore } from "zustand"
+
+interface PricesState {
+  prices: Map<string, number>
+  lastUpdated: Map<string, number>
+  subscriptions: Set<string>
+}
+
+type PricesContextValue = {
+  store: StoreApi<PricesState>
+  handleSubscribe: ({
+    exchange,
+    baseAddress,
+  }: {
+    exchange: Exchange
+    baseAddress: `0x${string}`
+  }) => void
+}
+
+const PriceStoreContext = createContext<PricesContextValue | null>(null)
+
+export const PriceStoreProvider: React.FC<
+  PropsWithChildren & {
+    initialPrices: Map<string, number>
+  }
+> = ({ children, initialPrices }) => {
+  const [store] = useState(() =>
+    createStore<PricesState>()(() => {
+      const initialLastUpdated = new Map<string, number>()
+      initialPrices.forEach((_, key) => {
+        initialLastUpdated.set(key, Date.now())
+      })
+      return {
+        prices: initialPrices ?? new Map(),
+        lastUpdated: initialLastUpdated,
+        subscriptions: new Set(),
+      }
+    })
+  )
+
+  const { readyState, sendJsonMessage } = useWebSocket(
+    "wss://dev.price-reporter.renegade.fi:4000/",
+    {
+      filter: () => false,
+      onMessage: (event) => {
+        try {
+          const data = JSON.parse(event.data)
+
+          if (data.topic && data.price) {
+            const { topic, price } = data
+            const prevPrice = store.getState().prices.get(topic)
+            const d = TICKER_TO_DEFAULT_DECIMALS[topic.split("-")[1]]
+            const priceNeedsUpdate =
+              !prevPrice || prevPrice.toFixed(d) !== price.toFixed(d)
+
+            if (priceNeedsUpdate) {
+              store.setState((state) => ({
+                prices: new Map(state.prices).set(topic, price),
+              }))
+            }
+
+            store.setState((state) => ({
+              lastUpdated: new Map(state.lastUpdated).set(topic, Date.now()),
+            }))
+          } else if (data.subscriptions) {
+            store.setState((state) => ({
+              subscriptions: new Set(state.subscriptions),
+            }))
+          }
+        } catch (error) {
+          console.error(`Failed to parse message: ${event.data}`)
+        }
+      },
+      shouldReconnect: () => true,
+    }
+  )
+
+  useEffect(() => {
+    if (readyState === ReadyState.OPEN) {
+      for (const token of tokenMapping.tokens) {
+        const topic = `binance-${token.address}-${DEFAULT_QUOTE.binance}`
+        sendJsonMessage({
+          method: "subscribe",
+          topic,
+        })
+      }
+    }
+  }, [readyState, sendJsonMessage])
+
+  const handleSubscribe = ({
+    exchange = "binance",
+    baseAddress,
+  }: {
+    exchange: Exchange
+    baseAddress: `0x${string}`
+  }) => {
+    console.log("Request to subscribe to ", exchange, baseAddress)
+    const topic = `${exchange}-${baseAddress}-${DEFAULT_QUOTE[exchange]}`
+    if (!store.getState().subscriptions.has(topic)) {
+      console.log("Subscribing to ", topic)
+      sendJsonMessage({
+        method: "subscribe",
+        topic,
+      })
+    }
+  }
+
+  return (
+    <PriceStoreContext.Provider value={{ store, handleSubscribe }}>
+      {children}
+    </PriceStoreContext.Provider>
+  )
+}
+
+export const usePrice = ({
+  exchange = "binance",
+  baseAddress,
+}: {
+  exchange?: Exchange
+  baseAddress: `0x${string}`
+}) => {
+  const context = useContext(PriceStoreContext)
+  if (!context) {
+    throw new Error("usePrice must be used within a PriceStoreProvider")
+  }
+
+  const { store, handleSubscribe } = context
+  const topic = `${exchange}-${baseAddress}-${DEFAULT_QUOTE[exchange]}`
+  const price = useStore(store, (state) => state.prices.get(topic))
+
+  useEffect(() => {
+    handleSubscribe({ exchange, baseAddress })
+  }, [baseAddress, exchange, handleSubscribe])
+
+  return price ?? 0
+}
+
+export const useLastUpdated = ({
+  exchange = "binance",
+  baseAddress,
+}: {
+  exchange?: Exchange
+  baseAddress: `0x${string}`
+}) => {
+  const context = useContext(PriceStoreContext)
+  if (!context) {
+    throw new Error("useLastUpdated must be used within a PriceStoreProvider")
+  }
+  const { store } = context
+  const topic = `${exchange}-${baseAddress}-${DEFAULT_QUOTE[exchange]}`
+  return useStore(store, (state) => state.lastUpdated.get(topic)) ?? 0
+}
+
+export const DEFAULT_QUOTE: Record<Exchange, `0x${string}`> = {
+  binance: Token.findByTicker("USDT").address,
+  coinbase: Token.findByTicker("USDC").address,
+  kraken: "0x0000000000000000000000000000000000000000" as `0x${string}`,
+  okx: Token.findByTicker("USDT").address,
+}

--- a/trade.renegade.fi/hooks/use-usd-price.ts
+++ b/trade.renegade.fi/hooks/use-usd-price.ts
@@ -1,21 +1,13 @@
-import { usePrice } from "@/contexts/PriceContext/price-context"
+import { usePrice } from "@/contexts/price-context"
 import { Token } from "@renegade-fi/react"
-import { useEffect, useState } from "react"
 import { formatUnits, parseUnits } from "viem/utils"
 
 // Returns USD price of the given amount of the base token
 export const useUSDPrice = (base: Token, amount?: bigint) => {
-  const [price, setPrice] = useState(0)
-
-  const { handleSubscribe, handleGetPrice } = usePrice()
-  const priceReport = handleGetPrice("binance", base.address)
-  useEffect(() => {
-    if (!priceReport) return
-    setPrice(priceReport)
-  }, [priceReport])
-  useEffect(() => {
-    handleSubscribe("binance", base.address)
-  }, [base, handleSubscribe])
+  const price = usePrice({
+    exchange: "binance",
+    baseAddress: base.address,
+  })
 
   return (
     price *

--- a/trade.renegade.fi/lib/utils.ts
+++ b/trade.renegade.fi/lib/utils.ts
@@ -1,4 +1,5 @@
 import { FUNDED_ADDRESSES } from "@/constants/storage-keys"
+import { Token, tokenMapping } from "@renegade-fi/react"
 import { Metadata } from "next"
 import numeral from "numeral"
 import { formatUnits } from "viem/utils"
@@ -233,3 +234,17 @@ export const fundList: { ticker: string; amount: string }[] = [
     amount: "100",
   },
 ]
+
+export async function getInitialPrices(): Promise<Map<string, number>> {
+  const baseUrl = process.env.NEXT_PUBLIC_PRICE_REPORTER_URL
+  const usdtAddress = Token.findByTicker("USDT").address
+
+  const promises = tokenMapping.tokens.map((token) => {
+    const topic = `binance-${token.address}-${usdtAddress}`
+    return fetch(`https://${baseUrl}:3000/price/${topic}`)
+      .then((res) => res.text())
+      .then((price) => [topic, parseFloat(price)] as [string, number])
+  })
+  const results = await Promise.all(promises)
+  return new Map(results)
+}

--- a/trade.renegade.fi/package.json
+++ b/trade.renegade.fi/package.json
@@ -34,12 +34,14 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-use-intercom": "^5.1.4",
+    "react-use-websocket": "^4.8.1",
     "simplebar-react": "^3.2.4",
     "sonner": "^1.4.0",
     "usehooks-ts": "^2.13.0",
     "uuid": "^9.0.1",
     "viem": "^2.9.28",
-    "wagmi": "^2.5.7"
+    "wagmi": "^2.5.7",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^13.4.19",

--- a/trade.renegade.fi/pnpm-lock.yaml
+++ b/trade.renegade.fi/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-use-intercom:
         specifier: ^5.1.4
         version: 5.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-use-websocket:
+        specifier: ^4.8.1
+        version: 4.8.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       simplebar-react:
         specifier: ^3.2.4
         version: 3.2.4(react@18.2.0)
@@ -86,6 +89,9 @@ importers:
       wagmi:
         specifier: ^2.5.7
         version: 2.5.19(@react-native-async-storage/async-storage@1.23.1(react-native@0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(react@18.2.0)))(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(react@18.2.0))(react@18.2.0)(typescript@5.1.6)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(zod@3.22.4)
+      zustand:
+        specifier: ^4.5.2
+        version: 4.5.2(@types/react@18.2.77)(react@18.2.0)
     devDependencies:
       '@next/bundle-analyzer':
         specifier: ^13.4.19


### PR DESCRIPTION
This PR uses `zustand` to create a single store to store price data for tokens. Consumers of this store react only to topics they care about, ensuring that rerenders happen only at the leaves of the DOM tree, namely `LivePrices.tsx`, `PlaceholderButton.tsx`, and select others. Also implemented is a server side fetch of initial prices, ensuring that most prices are fetched on page load and hydrated thereafter, avoiding a page full of `$0000.00`.