### PR TITLE
trade: prevent error on USDT

### DIFF
--- a/trade.renegade.fi/app/(desktop)/trading.tsx
+++ b/trade.renegade.fi/app/(desktop)/trading.tsx
@@ -3,6 +3,7 @@
 import { PlaceOrderButton } from "@/app/(desktop)/place-order-button"
 import { ViewEnum, useApp } from "@/contexts/App/app-context"
 import { usePrice } from "@/contexts/price-context"
+import { STABLECOINS } from "@/lib/tokens"
 import { Direction } from "@/lib/types"
 import { ChevronDownIcon } from "@chakra-ui/icons"
 import {
@@ -26,7 +27,6 @@ import { useUSDPrice } from "@/hooks/use-usd-price"
 import { BlurredOverlay } from "@/components/modals/blurred-overlay"
 import { TradingTokenSelectModal } from "@/components/modals/renegade-token-select-modal"
 
-const DISABLED_BASE_TOKENS = ["USDC"]
 interface SelectableProps {
   text: string
   onClick: () => void
@@ -103,7 +103,7 @@ export function TradingBody() {
   }, [baseTokenAmount, buySellSelectableRef])
 
   useEffect(() => {
-    if (view === ViewEnum.TRADING && DISABLED_BASE_TOKENS.includes(base)) {
+    if (view === ViewEnum.TRADING && STABLECOINS.includes(base)) {
       setBase("WETH")
     }
   }, [base, setBase, view])

--- a/trade.renegade.fi/app/(desktop)/trading.tsx
+++ b/trade.renegade.fi/app/(desktop)/trading.tsx
@@ -26,6 +26,7 @@ import { useUSDPrice } from "@/hooks/use-usd-price"
 import { BlurredOverlay } from "@/components/modals/blurred-overlay"
 import { TradingTokenSelectModal } from "@/components/modals/renegade-token-select-modal"
 
+const DISABLED_BASE_TOKENS = ["USDC"]
 interface SelectableProps {
   text: string
   onClick: () => void
@@ -102,7 +103,7 @@ export function TradingBody() {
   }, [baseTokenAmount, buySellSelectableRef])
 
   useEffect(() => {
-    if (view === ViewEnum.TRADING && base === "USDC") {
+    if (view === ViewEnum.TRADING && DISABLED_BASE_TOKENS.includes(base)) {
       setBase("WETH")
     }
   }, [base, setBase, view])

--- a/trade.renegade.fi/components/banners/tokens-banner.tsx
+++ b/trade.renegade.fi/components/banners/tokens-banner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
+import { DISPLAY_TOKENS } from "@/lib/tokens"
 import { Stack, Text } from "@chakra-ui/react"
-import { tokenMapping } from "@renegade-fi/react"
 import { useLocalStorage } from "usehooks-ts"
 
 import Marquee from "@/components/banners/marquee"
@@ -11,9 +11,7 @@ export function TokensBanner({}: { prices?: number[] }) {
   const [_, setBaseToken] = useLocalStorage("base", "WETH", {
     initializeWithValue: false,
   })
-  const tokens = tokenMapping.tokens.filter(
-    ({ ticker }) => !["USDC", "USDT"].includes(ticker)
-  )
+  const tokens = DISPLAY_TOKENS({ hideStables: true })
   return (
     <Marquee
       autoFill

--- a/trade.renegade.fi/components/modals/erc20-token-select-modal.tsx
+++ b/trade.renegade.fi/components/modals/erc20-token-select-modal.tsx
@@ -1,8 +1,8 @@
 import { wagmiConfig } from "@/app/providers"
 import { readErc20BalanceOf } from "@/generated"
-import { TICKER_TO_NAME } from "@/lib/tokens"
+import { DISPLAY_TOKENS, TICKER_TO_NAME } from "@/lib/tokens"
 import { formatNumber } from "@/lib/utils"
-import { Token, tokenMapping } from "@renegade-fi/react"
+import { Token } from "@renegade-fi/react"
 import { useEffect, useMemo, useState } from "react"
 import { useLocalStorage } from "usehooks-ts"
 import { useAccount, useBlockNumber } from "wagmi"
@@ -15,7 +15,6 @@ type ERC20TokenSelectModalProps = {
   isOpen: boolean
   onClose: () => void
 }
-const tokens = tokenMapping.tokens
 export function ERC20TokenSelectModal({
   isOpen,
   onClose,
@@ -37,7 +36,7 @@ export function ERC20TokenSelectModal({
       if (!address) {
         return
       }
-      const balancePromises = tokens.map(async (token) => {
+      const balancePromises = DISPLAY_TOKENS().map(async (token) => {
         const balance = await readErc20BalanceOf(wagmiConfig, {
           address: token.address as `0x${string}`,
           args: [address ?? "0x"],

--- a/trade.renegade.fi/components/modals/renegade-token-select-modal.tsx
+++ b/trade.renegade.fi/components/modals/renegade-token-select-modal.tsx
@@ -1,6 +1,6 @@
-import { TICKER_TO_NAME } from "@/lib/tokens"
+import { DISPLAY_TOKENS, TICKER_TO_NAME } from "@/lib/tokens"
 import { formatNumber } from "@/lib/utils"
-import { Token, tokenMapping, useBalances } from "@renegade-fi/react"
+import { Token, useBalances } from "@renegade-fi/react"
 import { useMemo, useState } from "react"
 import { useLocalStorage } from "usehooks-ts"
 
@@ -16,7 +16,6 @@ export function TradingTokenSelectModal({
   isOpen,
   onClose,
 }: TradingTokenSelectModalProps) {
-  const tokens = tokenMapping.tokens
   const balances = useBalances()
   const [_, setBase] = useLocalStorage("base", "WETH", {
     initializeWithValue: false,
@@ -25,7 +24,7 @@ export function TradingTokenSelectModal({
   const debouncedSearchTerm = useDebounce(searchTerm, 300)
 
   const filteredBalances = useMemo(() => {
-    return tokens
+    return DISPLAY_TOKENS()
       .filter(({ address }) => {
         const ticker = Token.findByAddress(address as `0x${string}`).ticker
         const name = Token.findByAddress(address as `0x${string}`).name
@@ -52,7 +51,7 @@ export function TradingTokenSelectModal({
           true
         ),
       }))
-  }, [balances, debouncedSearchTerm, tokens])
+  }, [balances, debouncedSearchTerm])
 
   return (
     <TokenSelectModal

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -2,6 +2,7 @@
 
 import { ConnectWalletButton, SignInButton } from "@/app/(desktop)/main-nav"
 import { ViewEnum, useApp } from "@/contexts/App/app-context"
+import { DISPLAY_TOKENS } from "@/lib/tokens"
 import {
   AIRDROP_TOOLTIP,
   RENEGADE_ACCOUNT_TOOLTIP,
@@ -13,7 +14,6 @@ import { ArrowDownIcon, ArrowUpIcon } from "@chakra-ui/icons"
 import { Box, Button, Flex, Spacer, Text } from "@chakra-ui/react"
 import {
   Token,
-  tokenMapping,
   useBalances,
   useStatus,
   useTaskHistory,
@@ -206,7 +206,7 @@ function RenegadeWalletPanel() {
     const nonzero: Array<[`0x${string}`, bigint]> = Object.entries(
       balances
     ).map(([_, b]) => [b.mint, b.amount])
-    const placeholders: Array<[`0x${string}`, bigint]> = tokenMapping.tokens
+    const placeholders: Array<[`0x${string}`, bigint]> = DISPLAY_TOKENS()
       .filter((t) => !nonzero.some(([a]) => a === t.address))
       .map((t) => [t.address as `0x${string}`, BigInt(0)])
 

--- a/trade.renegade.fi/contexts/price-context.tsx
+++ b/trade.renegade.fi/contexts/price-context.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { TICKER_TO_DEFAULT_DECIMALS } from "@/lib/tokens"
-import { Exchange, Token, tokenMapping } from "@renegade-fi/react"
+import { DISPLAY_TOKENS, TICKER_TO_DEFAULT_DECIMALS } from "@/lib/tokens"
+import { Exchange, Token } from "@renegade-fi/react"
 import {
   PropsWithChildren,
   createContext,
@@ -89,7 +89,7 @@ export const PriceStoreProvider: React.FC<
 
   useEffect(() => {
     if (readyState === ReadyState.OPEN) {
-      for (const token of tokenMapping.tokens) {
+      for (const token of DISPLAY_TOKENS({ hideStables: true })) {
         const topic = `binance-${token.address}-${DEFAULT_QUOTE.binance}`
         sendJsonMessage({
           method: "subscribe",

--- a/trade.renegade.fi/contexts/price-context.tsx
+++ b/trade.renegade.fi/contexts/price-context.tsx
@@ -135,14 +135,15 @@ export const usePrice = ({
   }
 
   const { store, handleSubscribe } = context
-  const topic = `${exchange}-${baseAddress}-${DEFAULT_QUOTE[exchange]}`
+  const quoteAddress = DEFAULT_QUOTE[exchange]
+  const topic = `${exchange}-${baseAddress}-${quoteAddress}`
   const price = useStore(store, (state) => state.prices.get(topic))
 
   useEffect(() => {
     handleSubscribe({ exchange, baseAddress })
-  }, [baseAddress, exchange, handleSubscribe])
+  }, [baseAddress, exchange, handleSubscribe, quoteAddress])
 
-  return price ?? 0
+  return price ? price : 0
 }
 
 export const useLastUpdated = ({

--- a/trade.renegade.fi/lib/tokens.tsx
+++ b/trade.renegade.fi/lib/tokens.tsx
@@ -33,7 +33,31 @@ import truLogo from "@/icons/tokens/tru.png"
 import usdtLogo from "@/icons/tokens/usdt.png"
 import wbtcLogo from "@/icons/tokens/wbtc.png"
 import wethLogo from "@/icons/tokens/weth.png"
+import { tokenMapping } from "@renegade-fi/react"
 import { StaticImageData } from "next/image"
+
+export const HIDDEN_TICKERS = ["USDT", "REN"]
+export const STABLECOINS = ["USDC", "USDT"]
+export const DISPLAY_TOKENS = (
+  options: {
+    hideStables?: boolean
+    hideHidden?: boolean
+    hideTickers?: Array<string>
+  } = {}
+) => {
+  const { hideStables, hideHidden = true, hideTickers = [] } = options
+  let tokens = tokenMapping.tokens
+  if (hideStables) {
+    tokens = tokens.filter((token) => !STABLECOINS.includes(token.ticker))
+  }
+  if (hideHidden) {
+    tokens = tokens.filter((token) => !HIDDEN_TICKERS.includes(token.ticker))
+  }
+  if (hideTickers.length > 0) {
+    tokens = tokens.filter((token) => !hideTickers.includes(token.ticker))
+  }
+  return tokens
+}
 
 const TOKENLIST_URL =
   "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/tokenlist.json"

--- a/trade.renegade.fi/lib/utils.ts
+++ b/trade.renegade.fi/lib/utils.ts
@@ -1,5 +1,6 @@
 import { FUNDED_ADDRESSES } from "@/constants/storage-keys"
-import { Token, tokenMapping } from "@renegade-fi/react"
+import { DISPLAY_TOKENS } from "@/lib/tokens"
+import { Token } from "@renegade-fi/react"
 import { Metadata } from "next"
 import numeral from "numeral"
 import { formatUnits } from "viem/utils"
@@ -239,7 +240,7 @@ export async function getInitialPrices(): Promise<Map<string, number>> {
   const baseUrl = process.env.NEXT_PUBLIC_PRICE_REPORTER_URL
   const usdtAddress = Token.findByTicker("USDT").address
 
-  const promises = tokenMapping.tokens.map((token) => {
+  const promises = DISPLAY_TOKENS({ hideStables: true }).map((token) => {
     const topic = `binance-${token.address}-${usdtAddress}`
     return fetch(`https://${baseUrl}:3000/price/${topic}`)
       .then((res) => res.text())


### PR DESCRIPTION
This PR fixes panics when USDT was selected as the base asset. Users who were previously stuck will have their state recovered, and USDT + REN have been hidden in the frontend to prevent future panics.