### PR TITLE
trade: prevent disconnect on chain id change

### DIFF
--- a/trade.renegade.fi/contexts/App/app-context.tsx
+++ b/trade.renegade.fi/contexts/App/app-context.tsx
@@ -51,12 +51,11 @@ function AppProvider({
         uid: string
       }
     ) => {
-      disconnect(config)
-      if (
-        data.accounts &&
-        (!fundedAddresses || !fundedAddresses.includes(data.accounts[0]))
-      ) {
-        fundWallet(fundList, data.accounts[0])
+      if (data.accounts) {
+        disconnect(config)
+        if (!fundedAddresses || !fundedAddresses.includes(data.accounts[0])) {
+          fundWallet(fundList, data.accounts[0])
+        }
       }
     }
 


### PR DESCRIPTION
This PR prevents the Renegade account from disconnecting when the user changes their active chain. Preserves disconnect functionality on account change.