### PR TITLE
trade: lower bg image z index

### DIFF
--- a/trade.renegade.fi/app/(desktop)/page.tsx
+++ b/trade.renegade.fi/app/(desktop)/page.tsx
@@ -17,7 +17,13 @@ export default function Page() {
         position: "relative",
       }}
     >
-      <Image alt="" fill priority src={backgroundPattern} />
+      <Image
+        alt=""
+        fill
+        priority
+        src={backgroundPattern}
+        style={{ zIndex: -1 }}
+      />
       <MedianBannerWrapper />
       <div style={{ flexGrow: 1, display: "flex" }}>
         <WalletsPanel />


### PR DESCRIPTION
This PR lowers the z index of the bg image so that median banner and relayer status banner elements can be hovered over (for tooltips).