### PR TITLE
trade: fix max error on trading page

### DIFF
--- a/trade.renegade.fi/app/(desktop)/trading.tsx
+++ b/trade.renegade.fi/app/(desktop)/trading.tsx
@@ -20,7 +20,6 @@ import {
 import { Token } from "@renegade-fi/react"
 import numeral from "numeral"
 import React, { createRef, useEffect, useRef, useState } from "react"
-import { toast } from "sonner"
 import { useLocalStorage } from "usehooks-ts"
 
 import { useMax } from "@/hooks/use-max"

--- a/trade.renegade.fi/lib/utils.ts
+++ b/trade.renegade.fi/lib/utils.ts
@@ -249,3 +249,11 @@ export async function getInitialPrices(): Promise<Map<string, number>> {
   const results = await Promise.all(promises)
   return new Map(results)
 }
+
+export function calculateMaxQuote(maxQuote: number, usdPrice: number) {
+  const baseMax = (maxQuote / usdPrice) * 0.99
+  if (baseMax < 0.000001) {
+    return
+  }
+  return baseMax
+}


### PR DESCRIPTION
This PR fixes an issue where the app would panic if a number (in scientific notation because it's so small) was cast to a BigInt.