### PR TITLE
trade: rename to faucet, guard ETH funding

### DIFF
--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -4,7 +4,7 @@ import { ConnectWalletButton, SignInButton } from "@/app/(desktop)/main-nav"
 import { ViewEnum, useApp } from "@/contexts/App/app-context"
 import { DISPLAY_TOKENS } from "@/lib/tokens"
 import {
-  AIRDROP_TOOLTIP,
+  FAUCET_TOOLTIP,
   RENEGADE_ACCOUNT_TOOLTIP,
   TASK_HISTORY_TOOLTIP,
 } from "@/lib/tooltip-labels"
@@ -146,7 +146,7 @@ function TokenBalance(props: TokenBalanceProps) {
 function DepositWithdrawButtons() {
   const { address } = useAccountWagmi()
   return (
-    <Tooltip placement="right" label={AIRDROP_TOOLTIP}>
+    <Tooltip placement="right" label={FAUCET_TOOLTIP}>
       <Flex
         flexDirection="row"
         width="100%"
@@ -180,7 +180,7 @@ function DepositWithdrawButtons() {
             fundWallet(fundList.slice(2), address)
           }}
         >
-          <Text>Airdrop</Text>
+          <Text>Faucet</Text>
           <ArrowDownIcon transition="color 0.3s ease" />
         </Flex>
       </Flex>

--- a/trade.renegade.fi/lib/tooltip-labels.tsx
+++ b/trade.renegade.fi/lib/tooltip-labels.tsx
@@ -22,7 +22,7 @@ export const RELAYER_NAME_TOOLTIP =
   "Your currently connected relayer. Your relayer can view your private orders, but does not control your funds."
 export const TVL_TOOLTIP =
   "The total amount that has been deposited into the Renegade pools. "
-export const AIRDROP_TOOLTIP = "Click to get more testnet funds."
+export const FAUCET_TOOLTIP = "Click to get more testnet funds."
 export const ACTIVE_ORDERS_TOOLTIP =
   "The total number of outstanding orders in Renegade."
 export const ORDER_TOOLTIP = (


### PR DESCRIPTION
This PR renames "Airdrop" -> "Faucet" and also checks the ETH balance of the requesting user to ensure we don't overfund with ETH.