### PR TITLE
trade: fix eth funding check

### DIFF
--- a/trade.renegade.fi/app/api/fund/route.ts
+++ b/trade.renegade.fi/app/api/fund/route.ts
@@ -91,7 +91,7 @@ async function fundEth(
   ethAmount: bigint
 ): Promise<void> {
   const ethBalance = await publicClient.getBalance({
-    address: account.address,
+    address: recipient,
   })
   if (ethBalance > APPROVAL_COST) {
     console.log("Skipping ETH funding")


### PR DESCRIPTION
This PR fixes a mistake in a previous PR that checks the ETH balance of the dev key instead of the user.