### PR TITLE
trade: downstream API changes for orders / tasks

### DIFF
--- a/trade.renegade.fi/app/order-toaster.tsx
+++ b/trade.renegade.fi/app/order-toaster.tsx
@@ -29,22 +29,25 @@ export function OrderToaster() {
       orderMetadataRef.current.set(incomingOrder.id, incomingOrder)
 
       const {
-        filled,
+        fills,
         state,
-        data: { base_mint, side },
+        data: { base_mint, side, amount },
       } = incomingOrder
       const base = Token.findByAddress(base_mint)
-      const formattedFilled = formatNumber(filled, base.decimals)
-      const lastFilled = existingOrder?.filled || BigInt(0)
+      const formattedAmount = formatNumber(amount, base.decimals)
+      const prevFills = existingOrder?.fills || []
 
       if (state === OrderState.Filled) {
         toast.success(
           `Order completely filled: ${
             side === "Buy" ? "Bought" : "Sold"
-          } ${formattedFilled} ${base.ticker}`
+          } ${formattedAmount} ${base.ticker}`
         )
-      } else if (filled > lastFilled) {
-        const currentFill = filled - lastFilled
+      } else if (fills.length > prevFills.length) {
+        const sortedFills = fills.sort((a, b) =>
+          a.timestamp > b.timestamp ? 1 : -1
+        )
+        const currentFill = sortedFills[sortedFills.length - 1].amount
         const formattedCurrentFill = formatNumber(currentFill, base.decimals)
         toast.success(
           `Order partially filled: ${

--- a/trade.renegade.fi/components/panels/orders-panel.tsx
+++ b/trade.renegade.fi/components/panels/orders-panel.tsx
@@ -54,7 +54,7 @@ function SingleOrder({
   const {
     id,
     state,
-    filled,
+    fills,
     created,
     data: { amount, base_mint, quote_mint, side },
   } = order
@@ -65,10 +65,12 @@ function SingleOrder({
   const quote = Token.findByAddress(quote_mint)
   const formattedAmount = formatNumber(amount, base.decimals)
   const formattedAmountLong = formatNumber(amount, base.decimals, true)
-  const remaining = BigInt(amount) - BigInt(filled)
+  const sortedFills = fills.sort((a, b) => (a.timestamp > b.timestamp ? 1 : -1))
+  const latestFill = sortedFills[sortedFills.length - 1]?.amount ?? 0
+  const remaining = BigInt(amount) - BigInt(latestFill)
   const formattedRemaining = formatNumber(remaining, base.decimals)
   const formattedRemainingLong = formatNumber(
-    BigInt(amount) - BigInt(filled),
+    BigInt(amount) - BigInt(latestFill),
     base.decimals,
     true
   )
@@ -77,7 +79,9 @@ function SingleOrder({
   const amountLabelLong =
     state === OrderState.Filled ? formattedAmountLong : formattedRemainingLong
   const formattedState = getReadableState(state)
-  const fillLabel = `${Math.round((Number(filled) / Number(amount)) * 100)}%`
+  const fillLabel = `${Math.round(
+    (Number(latestFill) / Number(amount)) * 100
+  )}%`
   const isCancellable = [OrderState.Created, OrderState.Matching].includes(
     state
   )

--- a/trade.renegade.fi/components/panels/task-history-list.tsx
+++ b/trade.renegade.fi/components/panels/task-history-list.tsx
@@ -1,4 +1,6 @@
+import { FEES_TOOLTIP } from "@/lib/tooltip-labels"
 import { formatNumber } from "@/lib/utils"
+import { Box } from "@chakra-ui/react"
 import {
   TaskState,
   TaskType,
@@ -8,6 +10,7 @@ import {
 } from "@renegade-fi/react"
 
 import { TaskItem } from "@/components/panels/task-item"
+import { Tooltip } from "@/components/tooltip"
 
 export function TaskHistoryList() {
   const { data } = useTaskHistory()
@@ -54,14 +57,31 @@ export function TaskHistoryList() {
               />
             )
           case TaskType.PayOfflineFee:
+            const token = Token.findByAddress(task.task_info.mint)
             return (
-              <TaskItem
-                key={task.id}
-                name={formattedTaskType[task.task_info.task_type]}
-                createdAt={createdAt}
-                state={formattedState}
-                isFeeTask
-              />
+              <Tooltip placement="right" label={FEES_TOOLTIP}>
+                <Box>
+                  <TaskItem
+                    key={task.id}
+                    name={
+                      task.task_info.is_protocol
+                        ? "Protocol Fee"
+                        : "Relayer Fee"
+                    }
+                    createdAt={createdAt}
+                    state={formattedState}
+                    description={`${formatNumber(
+                      task.task_info.amount,
+                      token.decimals
+                    )} ${token.ticker}`}
+                    tooltip={`${formatNumber(
+                      task.task_info.amount,
+                      token.decimals,
+                      true
+                    )} ${token.ticker}`}
+                  />
+                </Box>
+              </Tooltip>
             )
           case TaskType.UpdateWallet:
             switch (task.task_info.update_type) {

--- a/trade.renegade.fi/components/panels/task-item.tsx
+++ b/trade.renegade.fi/components/panels/task-item.tsx
@@ -1,4 +1,3 @@
-import { FEES_TOOLTIP } from "@/lib/tooltip-labels"
 import { Box, Flex, Spinner, Text } from "@chakra-ui/react"
 import dayjs from "dayjs"
 import { CheckIcon, TriangleAlert } from "lucide-react"
@@ -8,14 +7,12 @@ import { Tooltip } from "../tooltip"
 export function TaskItem({
   createdAt,
   description,
-  isFeeTask,
   name,
   state,
   tooltip,
 }: {
   createdAt: number
   description?: string
-  isFeeTask?: boolean
   name: string
   state: string
   tooltip?: string
@@ -39,47 +36,42 @@ export function TaskItem({
       : "text.primary"
 
   return (
-    <Tooltip placement="right" label={isFeeTask ? FEES_TOOLTIP : ""}>
-      <Box
-        justifyContent="center"
-        padding="4% 6%"
-        color="text.secondary"
-        fontSize="0.8em"
-        borderBottom="var(--secondary-border)"
-        _hover={{
-          color: "text.primary",
-        }}
-        role="group"
+    <Box
+      justifyContent="center"
+      padding="4% 6%"
+      color="text.secondary"
+      fontSize="0.8em"
+      borderBottom="var(--secondary-border)"
+      _hover={{
+        color: "text.primary",
+      }}
+      role="group"
+    >
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+        minWidth="100%"
+        whiteSpace="nowrap"
       >
-        <Flex
-          alignItems="center"
-          justifyContent="space-between"
-          minWidth="100%"
-          whiteSpace="nowrap"
-        >
-          <Text fontSize="1.3em">{name}</Text>
-          <Flex gap="1" verticalAlign="middle">
-            <Box
-              _groupHover={{ color: iconColor }}
-              transition="color 0.3s ease"
-            >
-              {icon}
-            </Box>
-            <Text>{state}</Text>
-          </Flex>
+        <Text fontSize="1.3em">{name}</Text>
+        <Flex gap="1" verticalAlign="middle">
+          <Box _groupHover={{ color: iconColor }} transition="color 0.3s ease">
+            {icon}
+          </Box>
+          <Text>{state}</Text>
         </Flex>
-        <Flex
-          alignItems="center"
-          justifyContent="space-between"
-          minWidth="100%"
-          whiteSpace="nowrap"
-        >
-          <Tooltip label={tooltip}>
-            <Text>{description}</Text>
-          </Tooltip>
-          <Text>{dayjs.unix(createdAt).fromNow()}</Text>
-        </Flex>
-      </Box>
-    </Tooltip>
+      </Flex>
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+        minWidth="100%"
+        whiteSpace="nowrap"
+      >
+        <Tooltip label={tooltip}>
+          <Text>{description}</Text>
+        </Tooltip>
+        <Text>{dayjs.unix(createdAt).fromNow()}</Text>
+      </Flex>
+    </Box>
   )
 }

--- a/trade.renegade.fi/package.json
+++ b/trade.renegade.fi/package.json
@@ -22,7 +22,7 @@
     "@datadog/browser-rum": "^5.15.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@renegade-fi/react": "0.0.40",
+    "@renegade-fi/react": "0.0.41",
     "@t3-oss/env-nextjs": "^0.6.0",
     "@tanstack/react-query": "^5.24.1",
     "@vercel/analytics": "^1.2.2",

--- a/trade.renegade.fi/pnpm-lock.yaml
+++ b/trade.renegade.fi/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^11.11.0
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.2.77)(react@18.2.0))(@types/react@18.2.77)(react@18.2.0)
       '@renegade-fi/react':
-        specifier: 0.0.40
-        version: 0.0.40(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)
+        specifier: 0.0.41
+        version: 0.0.41(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)
       '@t3-oss/env-nextjs':
         specifier: ^0.6.0
         version: 0.6.1(typescript@5.1.6)(zod@3.22.4)
@@ -2081,16 +2081,16 @@ packages:
     peerDependencies:
       react-native: '*'
 
-  '@renegade-fi/core@0.0.39':
-    resolution: {integrity: sha512-DZBnGHfqOvxaFNWgyA0WuEBQoFxYDD2X/L+zFWXk0k6RVNmrDasmxPjwUfkPHtp6SC2JGkwagr3R7a4lQbCk/A==}
+  '@renegade-fi/core@0.0.40':
+    resolution: {integrity: sha512-SY2zRfjGkI7tpgKetzDBePz0mqPiBiPb1zGtlvAwX16n0iKbHPF7OPeJZc89dKkrsmvNs5V5OzBGZY0edoEx5Q==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
 
-  '@renegade-fi/react@0.0.40':
-    resolution: {integrity: sha512-vWxA7wMfeJHs3t81fOb5CVSc3RfGOiv0vV4CNdEJ7KPRFYqnzCoXL4+eAJ6vlArKdI5RsZcGOKl+wnLK+hH9cg==}
+  '@renegade-fi/react@0.0.41':
+    resolution: {integrity: sha512-1L9D7/f0l4sh7GTijaKPqdVlpMlDogXJc/M84iZzLugd0XtGJRTNG6OR/hEk0FGpnnabqoKWSWldKR9rQr4zsg==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -8695,7 +8695,7 @@ snapshots:
       nullthrows: 1.1.1
       react-native: 0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(react@18.2.0)
 
-  '@renegade-fi/core@0.0.39(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)':
+  '@renegade-fi/core@0.0.40(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)':
     dependencies:
       axios: 1.7.2
       isomorphic-ws: 5.0.0(ws@8.13.0(bufferutil@4.0.8))
@@ -8716,9 +8716,9 @@ snapshots:
       - ws
       - zod
 
-  '@renegade-fi/react@0.0.40(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)':
+  '@renegade-fi/react@0.0.41(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)':
     dependencies:
-      '@renegade-fi/core': 0.0.39(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)
+      '@renegade-fi/core': 0.0.40(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.1.6)(ws@8.13.0(bufferutil@4.0.8))(zod@3.22.4)
       '@tanstack/react-query': 5.29.2(react@18.2.0)
       json-bigint: 1.0.0
       react: 18.2.0


### PR DESCRIPTION
This PR downstreams API response type changes from the relayer that adds more data to the `OrderMetadata` type and `PayFeeTask` type. Also refactors order-related types into their own file for readability.