### PR TITLE
trade: api: get-binance-orderbook: set up edge function for fetching Binance orderbook

### DIFF
--- a/trade.renegade.fi/app/api/get-binance-orderbook/route.ts
+++ b/trade.renegade.fi/app/api/get-binance-orderbook/route.ts
@@ -1,0 +1,124 @@
+import { PriceLevel } from "@/lib/price-simulation"
+import { NextRequest, NextResponse } from "next/server"
+
+export const dynamic = "force-dynamic"
+export const runtime = "edge"
+
+/**
+ * We want this to run as close as possible to the user,
+ * so we include all the regions supported by the Binance API.
+ */
+export const preferredRegion = [
+  "arn1",
+  "bom1",
+  "cdg1",
+  "cpt1",
+  "dub1",
+  "fra1",
+  "gru1",
+  "hkg1",
+  "hnd1",
+  "icn1",
+  "kix1",
+  "lhr1",
+  "sin1",
+  "syd1",
+]
+
+/** The URL of the Binance API endpoint that returns the current orderbook for a given symbol & depth */
+const BINANCE_DEPTH_URL = "https://api.binance.com/api/v3/depth"
+
+/** The response from the Binance API */
+type BinanceOrderbookResponse = {
+  lastUpdateId: number
+  bids: [string, string][]
+  asks: [string, string][]
+}
+
+/** The reponse data from this route */
+type OrderbookResponseData = {
+  bids: PriceLevel[]
+  asks: PriceLevel[]
+}
+
+/**
+ * The GET handler for this route, which fetches the current Binance orderbook
+ * for the given pair, and returns it in the expected format.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const symbol = getPairSymbolFromRequest(request)
+    const binanceOrderbook = await fetchBinanceOrderbook(symbol)
+    const orderbookRes = convertOrderbook(binanceOrderbook)
+
+    return NextResponse.json(orderbookRes)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}
+
+/**
+ * Parses the base and quote tickers from the request's query parameters,
+ * and remaps them to corresponding pair symbols that Binance expects.
+ */
+function getPairSymbolFromRequest(request: NextRequest): string {
+  const base_ticker = request.nextUrl.searchParams
+    .get("base_ticker")
+    ?.toUpperCase()
+  const quote_ticker = request.nextUrl.searchParams
+    .get("quote_ticker")
+    ?.toUpperCase()
+
+  if (!base_ticker || !quote_ticker) {
+    throw new Error("Missing base_ticker or quote_ticker query parameter")
+  }
+
+  const base = remapTickerName(base_ticker)
+  const quote = remapTickerName(quote_ticker)
+
+  return `${base}${quote}`
+}
+
+/** Remaps the given ticker name to the corresponding asset in Binance */
+function remapTickerName(ticker: string) {
+  if (ticker === "WBTC") {
+    return "BTC"
+  } else if (ticker === "WETH") {
+    return "ETH"
+  } else if (ticker === "USDC") {
+    return "USDT"
+  }
+  return ticker
+}
+
+/**
+ * Fetches the current Binance orderbook for the given pair symbol,
+ * up to the maximum supported depth (5000 levels).
+ */
+async function fetchBinanceOrderbook(
+  symbol: string
+): Promise<BinanceOrderbookResponse> {
+  const binance_url = new URL(BINANCE_DEPTH_URL)
+  binance_url.searchParams.set("symbol", symbol)
+  binance_url.searchParams.set("limit", "5000")
+
+  const res = await fetch(binance_url)
+  return res.json()
+}
+
+/** Converts the Binance orderbook data to the expected format */
+function convertOrderbook(
+  binanceOrderbook: BinanceOrderbookResponse
+): OrderbookResponseData {
+  const bids = binanceOrderbook.bids.map(parsePriceLevel)
+  const asks = binanceOrderbook.asks.map(parsePriceLevel)
+  return { bids, asks }
+}
+
+/** Parses a price level from the Binance orderbook into our `PriceLevel` type */
+function parsePriceLevel(rawPriceLevel: [string, string]): PriceLevel {
+  return {
+    price: parseFloat(rawPriceLevel[0]),
+    quantity: parseFloat(rawPriceLevel[1]),
+  }
+}

--- a/trade.renegade.fi/lib/price-simulation.tsx
+++ b/trade.renegade.fi/lib/price-simulation.tsx
@@ -1,0 +1,90 @@
+import { Direction } from "./types"
+
+/** A bid/ask price level in an order book for a given pair */
+export type PriceLevel = {
+  /** The level's price, denominated in the quote asset */
+  price: number
+  /** The amount of liquidity at this price level, denominated in the base asset */
+  quantity: number
+}
+
+/** An orderbook, comprised of bid/ask lists and a taker fee rate */
+export class Orderbook {
+  /**
+   * The orderbook bids (buy-side price levels), in descending order of price.
+   * Empty upon initialization.
+   */
+  bids: PriceLevel[] = []
+
+  /**
+   * The orderbook asks (sell-side price levels), in ascending order of price.
+   * Empty upon initialization.
+   */
+  asks: PriceLevel[] = []
+
+  /**
+   * The percentage fee to apply to trades against this orderbook.
+   * Defaults to 10 bips, this is the Binance taker fee for traders w/ <20M
+   * in monthly trading volume.
+   */
+  feeRate: number = 0.001
+
+  /** Adds bids to the orderbook, maintaining a descending sorting by price */
+  addBids(bids: PriceLevel[]) {
+    this.bids.push(...bids)
+    this.bids.sort((a, b) => b.price - a.price)
+  }
+
+  /** Adds asks to the orderbook, maintaining an ascending sorting by price */
+  addAsks(asks: PriceLevel[]) {
+    this.asks.push(...asks)
+    this.asks.sort((a, b) => a.price - b.price)
+  }
+
+  /** Sets the fee rate used by the orderbook */
+  setFeeRate(feeRate: number) {
+    this.feeRate = feeRate
+  }
+
+  /**
+   * Simulates the effective price of a trade on an orderbook, inclusive of fees
+   * @param quantity The amount of the base asset to trade
+   * @param direction The direction of the trade (buy/sell)
+   * @param feeRate The percentage fee to apply to the trade, deducted from the received asset
+   * @returns The effective price of the trade (inclusive of fees) denominated in the quote asset
+   */
+  simulateTradePrice(quantity: number, direction: Direction): number {
+    const levels = direction === Direction.BUY ? [...this.asks] : [...this.bids]
+    let remaining = quantity
+    let effectiveQuoteAmount = 0
+    while (remaining > 0) {
+      const level = levels.shift()
+      if (level === undefined) {
+        throw new Error("Insufficient price levels to simulate trade")
+      }
+
+      let filledAmount = Math.min(level.quantity, remaining)
+      effectiveQuoteAmount += filledAmount * level.price
+      remaining -= filledAmount
+    }
+
+    let effectiveBaseAmount =
+      direction === Direction.BUY ? quantity * (1 - this.feeRate) : quantity
+
+    effectiveQuoteAmount =
+      direction === Direction.SELL
+        ? effectiveQuoteAmount * (1 - this.feeRate)
+        : effectiveQuoteAmount
+
+    let effectivePrice = effectiveQuoteAmount / effectiveBaseAmount
+
+    return effectivePrice
+  }
+
+  /**
+   * @returns The midpoint price of the orderbook, denominated in the quote asset
+   */
+  midpointPrice(): number {
+    return (this.asks[0].price + this.bids[0].price) / 2
+  }
+}


### PR DESCRIPTION
This PR introduces an `/api/get-binance-orderbook` route that dispatches an Edge function configured to run in regions supported by the Binance API, which fetches the current orderbook for the given base & quote tickers (up to maximum depth).

This is being tested on the associated deployment.