### PR TITLE
trade: api: Vercel function for getting Binance orderbook 

### DIFF
--- a/trade.renegade.fi/app/api/get-binance-orderbook/route.ts
+++ b/trade.renegade.fi/app/api/get-binance-orderbook/route.ts
@@ -1,30 +1,72 @@
 import { PriceLevel } from "@/lib/price-simulation"
 
+// -------------
+// | CONSTANTS |
+// -------------
+
 /** The URL of the Amberdata REST API */
 const AMBERDATA_BASE_URL = "https://api.amberdata.com"
-
 /** The API endpoint for spot market orderbook snapshots */
 const AMBERDATA_ORDERBOOK_SNAPSHOTS_ROUTE = "markets/spot/order-book-snapshots"
+/** The API endpoint for spot market orderbook updates */
+const AMBERDATA_ORDERBOOK_UPDATES_ROUTE = "markets/spot/order-book-events"
 
 /** The Amberdata API key header */
 const API_KEY_HEADER = "x-api-key"
 
+/** The search parameter indicating the exchange to make a request for */
+const EXCHANGE_PARAM = "exchange"
 /** The identifier for the Binance exchange in the Amberdata API */
 const BINANCE_EXCHANGE_ID = "binance"
 
+/** The search parameter indicating the timestamp format for the Amberdata API to use */
+const TIME_FORMAT_PARAM = "timeFormat"
+/** The format for timestamps returned from the Amberdata API */
+const TIME_FORMAT = "milliseconds"
+
+/** The search parameter indicating the start date for the Amberdata API to use */
+const START_DATE_PARAM = "startDate"
+/** The search parameter indicating the end date for the Amberdata API to use */
+const END_DATE_PARAM = "endDate"
+
+// ---------
+// | TYPES |
+// ---------
+
 /**
- * The response from the Amberdata API.
+ * Amberdata's API response for an orderbook snapshot.
  * This type only specifies the subset of the response data
  * we are interested in.
  */
-type AmberdataOrderbookResponse = {
+type AmberdataOrderbookSnapshotResponse = {
   payload: {
-    data: {
-      timestamp: number
-      ask: AmberdataPriceLevel[]
-      bid: AmberdataPriceLevel[]
-    }[]
+    data: AmberdataOrderbookSnapshot[]
   }
+}
+
+/** Amberdata's format for an orderbook snapshot */
+type AmberdataOrderbookSnapshot = {
+  timestamp: number
+  ask: AmberdataPriceLevel[]
+  bid: AmberdataPriceLevel[]
+}
+
+/**
+ * Amberdata's API response for an orderbook update.
+ * This type only specifies the subset of the response data
+ * we are interested in.
+ */
+type AmberdataOrderbookUpdateResponse = {
+  payload: {
+    data: AmberdataOrderbookUpdate[]
+  }
+}
+
+/** Amberdata's format for an orderbook update */
+type AmberdataOrderbookUpdate = {
+  exchangeTimestamp: number
+  ask: AmberdataPriceLevel[]
+  bid: AmberdataPriceLevel[]
 }
 
 /**
@@ -35,12 +77,29 @@ type AmberdataPriceLevel = {
   volume: number
 }
 
+/**
+ * An intermediary representation of an orderbook, mapping prices to quantities.
+ * This is useful for applying updates onto a snapshot efficiently.
+ */
+type OrderbookMap = {
+  bids: {
+    [price: number]: number
+  }
+  asks: {
+    [price: number]: number
+  }
+}
+
 /** The reponse data from this route */
 type OrderbookResponseData = {
   timestamp: number
   bids: PriceLevel[]
   asks: PriceLevel[]
 }
+
+// -----------
+// | HANDLER |
+// -----------
 
 /**
  * The GET handler for this route, which fetches the current Binance orderbook
@@ -51,12 +110,7 @@ export async function GET(request: Request): Promise<Response> {
     const instrument = getInstrumentFromRequest(request)
     const timestamp = getTimestampFromRequest(request)
 
-    const binanceOrderbook = await fetchBinanceOrderbook(instrument, timestamp)
-    console.log(binanceOrderbook)
-
-    // TODO: Apply updates to get as close to timestamp as possible
-
-    const orderbookRes = convertOrderbook(binanceOrderbook)
+    const orderbookRes = await constructBinanceOrderbook(instrument, timestamp)
 
     return new Response(JSON.stringify(orderbookRes))
   } catch (e: any) {
@@ -64,40 +118,27 @@ export async function GET(request: Request): Promise<Response> {
   }
 }
 
+// -----------
+// | HELPERS |
+// -----------
+
 /**
  * Parses the base and quote tickers from the request's query parameters,
  * and remaps them to corresponding instrument that Amberdata expects
  */
 function getInstrumentFromRequest(request: Request): string {
   const requestUrl = new URL(request.url)
-  const base_ticker = requestUrl.searchParams.get("base_ticker")?.toLowerCase()
-  const quote_ticker = requestUrl.searchParams
-    .get("quote_ticker")
-    ?.toLowerCase()
+  const baseTicker = requestUrl.searchParams.get("base_ticker")?.toLowerCase()
+  const quoteTicker = requestUrl.searchParams.get("quote_ticker")?.toLowerCase()
 
-  if (!base_ticker || !quote_ticker) {
+  if (!baseTicker || !quoteTicker) {
     throw new Error("Missing base_ticker or quote_ticker query parameter")
   }
 
-  const base = remapTickerName(base_ticker)
-  const quote = remapTickerName(quote_ticker)
+  const base = remapTickerName(baseTicker)
+  const quote = remapTickerName(quoteTicker)
 
   return `${base}_${quote}`
-}
-
-/**
- * Parses the base and quote tickers from the request's query parameters,
- * and remaps them to corresponding instrument that Amberdata expects
- */
-function getTimestampFromRequest(request: Request): number {
-  const requestUrl = new URL(request.url)
-  const timestamp = requestUrl.searchParams.get("timestamp")
-
-  if (!timestamp) {
-    throw new Error("Missing timestamp query parameter")
-  }
-
-  return parseInt(timestamp)
 }
 
 /** Remaps the given ticker name to the corresponding instrument fragment in Amberdata */
@@ -112,46 +153,131 @@ function remapTickerName(ticker: string) {
   return ticker
 }
 
-/**
- * Fetches the current Binance orderbook for the given pair symbol,
- * up to the maximum supported depth (5000 levels).
- */
-async function fetchBinanceOrderbook(
-  instrument: string,
-  timestamp: number
-): Promise<AmberdataOrderbookResponse> {
-  let searchParams = [
-    ["exchange", BINANCE_EXCHANGE_ID],
-    ["timeFormat", "milliseconds"],
+/** Parses the timestamp from the request's query parameters */
+function getTimestampFromRequest(request: Request): number {
+  const requestUrl = new URL(request.url)
+  const timestamp = requestUrl.searchParams.get("timestamp")
 
-    // For the search range, we set [timestamp - 1min, timestamp + 1).
-    // This is to ensure that we get the most recent snapshot inclusive of the timestamp
-    // in the response
-    ["startDate", (timestamp - 60000).toString()],
-    ["endDate", (timestamp + 1).toString()],
-  ] as [string, string][]
+  if (!timestamp) {
+    throw new Error("Missing timestamp query parameter")
+  }
 
-  const req = await amberdataRequest(
-    `${AMBERDATA_ORDERBOOK_SNAPSHOTS_ROUTE}/${instrument}`,
-    searchParams
-  )
-
-  const res = await fetch(req)
-  return res.json()
+  return parseInt(timestamp)
 }
 
 /**
- * Constructs an Amberdata API GET request for the given route & search parameters,
- * setting the API key header appropriately
+ * Construct the Binance orderbook for the given instrument, at the given timestamp.
+ * This is done by fetching the most recent orderbook snapshot relative to the
+ * timestamp, then fetching all of the updates between the snapshot and the timestamp,
+ * and applying them on top of the snapshot.
+ */
+async function constructBinanceOrderbook(
+  instrument: string,
+  timestamp: number
+): Promise<OrderbookResponseData> {
+  const snapshot = await fetchBinanceOrderbookSnapshot(instrument, timestamp)
+  const updates = await fetchBinanceOrderbookUpdates(
+    instrument,
+    snapshot.timestamp,
+    timestamp
+  )
+
+  // Construct an initial orderbook map from the snapshot
+  let orderbookMap: OrderbookMap = {
+    bids: {},
+    asks: {},
+  }
+  snapshot.bid.forEach((level) => {
+    orderbookMap.bids[level.price] = level.volume
+  })
+  snapshot.ask.forEach((level) => {
+    orderbookMap.asks[level.price] = level.volume
+  })
+
+  // Apply the updates to the map
+  updates.forEach((update) => {
+    update.bid.forEach((level) => {
+      orderbookMap.bids[level.price] = level.volume
+    })
+    update.ask.forEach((level) => {
+      orderbookMap.asks[level.price] = level.volume
+    })
+  })
+
+  // Use the timestamp of the most recent update
+  // (they are given in ascending order by time, i.e. most recent is last)
+  const lastUpdateIdx = updates.length - 1
+  const finalTimestamp = updates[lastUpdateIdx].exchangeTimestamp
+
+  return convertOrderbookMap(orderbookMap, finalTimestamp)
+}
+
+/**
+ * Fetches a snapshot of the Binance orderbook for the given pair symbol,
+ * around the given timestamp (in milliseconds), up to the maximum supported depth (5000 levels).
+ */
+async function fetchBinanceOrderbookSnapshot(
+  instrument: string,
+  timestamp: number
+): Promise<AmberdataOrderbookSnapshot> {
+  // For the search range, we set [timestamp - 1min, timestamp + 1ms).
+  // This is to ensure that we get the most recent snapshot inclusive of the timestamp
+  const startDate = timestamp - 60000
+  const endDate = timestamp + 1
+
+  const req = await amberdataRequest(
+    `${AMBERDATA_ORDERBOOK_SNAPSHOTS_ROUTE}/${instrument}`,
+    startDate,
+    endDate
+  )
+
+  const res = await fetch(req)
+  const orderbookRes: AmberdataOrderbookSnapshotResponse = await res.json()
+
+  // The Amberdata response contains snapshots in ascending order of timestamp,
+  // i.e. most recent is last
+  const lastIdx = orderbookRes.payload.data.length - 1
+  return orderbookRes.payload.data[lastIdx]
+}
+
+/**
+ * Fetches all of the Binance orderbook updates for the given instrument,
+ * from the timestamp of the most recent snapshot, to the desired timestamp
+ */
+async function fetchBinanceOrderbookUpdates(
+  instrument: string,
+  snapshotTimestamp: number,
+  desiredTimestamp: number
+): Promise<Array<AmberdataOrderbookUpdate>> {
+  const req = await amberdataRequest(
+    `${AMBERDATA_ORDERBOOK_UPDATES_ROUTE}/${instrument}`,
+    snapshotTimestamp,
+    desiredTimestamp
+  )
+
+  const res = await fetch(req)
+  const updatesRes: AmberdataOrderbookUpdateResponse = await res.json()
+  return updatesRes.payload.data
+}
+
+/**
+ * Constructs an Amberdata API GET request for the given route,
+ * setting the search parameters & API key header appropriately.
+ *
+ * @param startDate - The starting timestamp for the search range, in milliseconds (inclusive)
+ * @param endDate - The ending timestamp for the search range, in milliseconds (exclusive)
  */
 async function amberdataRequest(
   route: string,
-  searchParams: [string, string][]
+  startDate: number,
+  endDate: number
 ): Promise<Request> {
   const amberdataUrl = new URL(`${AMBERDATA_BASE_URL}/${route}`)
-  for (const [key, value] of searchParams) {
-    amberdataUrl.searchParams.set(key, value)
-  }
+  amberdataUrl.searchParams.set(EXCHANGE_PARAM, BINANCE_EXCHANGE_ID)
+  amberdataUrl.searchParams.set(TIME_FORMAT_PARAM, TIME_FORMAT)
+  amberdataUrl.searchParams.set(START_DATE_PARAM, startDate.toString())
+  amberdataUrl.searchParams.set(END_DATE_PARAM, endDate.toString())
+
   let amberdataReq = new Request(amberdataUrl)
   amberdataReq.headers.set(
     API_KEY_HEADER,
@@ -161,22 +287,21 @@ async function amberdataRequest(
   return amberdataReq
 }
 
-/** Converts the Binance orderbook data to the expected format */
-function convertOrderbook(
-  binanceOrderbook: AmberdataOrderbookResponse
+/** Converts an orderbook map to a valid orderbook response */
+function convertOrderbookMap(
+  orderbookMap: OrderbookMap,
+  timestamp: number
 ): OrderbookResponseData {
-  let data = binanceOrderbook.payload.data
-  let lastIdx = data.length - 1
-  const bids = data[lastIdx].bid.map(parsePriceLevel)
-  const asks = data[lastIdx].ask.map(parsePriceLevel)
-  const timestamp = data[lastIdx].timestamp
-  return { bids, asks, timestamp }
-}
+  // Filter out the empty levels & sort in expected order
+  const bids = Object.entries(orderbookMap.bids)
+    .filter(([_price, volume]) => volume > 0)
+    .map(([price, quantity]) => ({ price: parseFloat(price), quantity }))
+    .sort((a, b) => b.price - a.price)
 
-/** Parses a price level from the Binance orderbook into our `PriceLevel` type */
-function parsePriceLevel(amberdataPriceLevel: AmberdataPriceLevel): PriceLevel {
-  return {
-    price: amberdataPriceLevel.price,
-    quantity: amberdataPriceLevel.volume,
-  }
+  const asks = Object.entries(orderbookMap.asks)
+    .filter(([_price, volume]) => volume > 0)
+    .map(([price, quantity]) => ({ price: parseFloat(price), quantity }))
+    .sort((a, b) => a.price - b.price)
+
+  return { bids, asks, timestamp }
 }

--- a/trade.renegade.fi/app/api/get-binance-orderbook/route.ts
+++ b/trade.renegade.fi/app/api/get-binance-orderbook/route.ts
@@ -1,0 +1,182 @@
+import { PriceLevel } from "@/lib/price-simulation"
+
+/** The URL of the Amberdata REST API */
+const AMBERDATA_BASE_URL = "https://api.amberdata.com"
+
+/** The API endpoint for spot market orderbook snapshots */
+const AMBERDATA_ORDERBOOK_SNAPSHOTS_ROUTE = "markets/spot/order-book-snapshots"
+
+/** The Amberdata API key header */
+const API_KEY_HEADER = "x-api-key"
+
+/** The identifier for the Binance exchange in the Amberdata API */
+const BINANCE_EXCHANGE_ID = "binance"
+
+/**
+ * The response from the Amberdata API.
+ * This type only specifies the subset of the response data
+ * we are interested in.
+ */
+type AmberdataOrderbookResponse = {
+  payload: {
+    data: {
+      timestamp: number
+      ask: AmberdataPriceLevel[]
+      bid: AmberdataPriceLevel[]
+    }[]
+  }
+}
+
+/**
+ * Amberdata's format for an orderbook price level
+ */
+type AmberdataPriceLevel = {
+  price: number
+  volume: number
+}
+
+/** The reponse data from this route */
+type OrderbookResponseData = {
+  timestamp: number
+  bids: PriceLevel[]
+  asks: PriceLevel[]
+}
+
+/**
+ * The GET handler for this route, which fetches the current Binance orderbook
+ * for the given pair, and returns it in the expected format.
+ */
+export async function GET(request: Request): Promise<Response> {
+  try {
+    const instrument = getInstrumentFromRequest(request)
+    const timestamp = getTimestampFromRequest(request)
+
+    const binanceOrderbook = await fetchBinanceOrderbook(instrument, timestamp)
+    console.log(binanceOrderbook)
+
+    // TODO: Apply updates to get as close to timestamp as possible
+
+    const orderbookRes = convertOrderbook(binanceOrderbook)
+
+    return new Response(JSON.stringify(orderbookRes))
+  } catch (e: any) {
+    return new Response(e.message, { status: 500 })
+  }
+}
+
+/**
+ * Parses the base and quote tickers from the request's query parameters,
+ * and remaps them to corresponding instrument that Amberdata expects
+ */
+function getInstrumentFromRequest(request: Request): string {
+  const requestUrl = new URL(request.url)
+  const base_ticker = requestUrl.searchParams.get("base_ticker")?.toLowerCase()
+  const quote_ticker = requestUrl.searchParams
+    .get("quote_ticker")
+    ?.toLowerCase()
+
+  if (!base_ticker || !quote_ticker) {
+    throw new Error("Missing base_ticker or quote_ticker query parameter")
+  }
+
+  const base = remapTickerName(base_ticker)
+  const quote = remapTickerName(quote_ticker)
+
+  return `${base}_${quote}`
+}
+
+/**
+ * Parses the base and quote tickers from the request's query parameters,
+ * and remaps them to corresponding instrument that Amberdata expects
+ */
+function getTimestampFromRequest(request: Request): number {
+  const requestUrl = new URL(request.url)
+  const timestamp = requestUrl.searchParams.get("timestamp")
+
+  if (!timestamp) {
+    throw new Error("Missing timestamp query parameter")
+  }
+
+  return parseInt(timestamp)
+}
+
+/** Remaps the given ticker name to the corresponding instrument fragment in Amberdata */
+function remapTickerName(ticker: string) {
+  if (ticker === "wbtc") {
+    return "btc"
+  } else if (ticker === "weth") {
+    return "eth"
+  } else if (ticker === "usdc") {
+    return "usdt"
+  }
+  return ticker
+}
+
+/**
+ * Fetches the current Binance orderbook for the given pair symbol,
+ * up to the maximum supported depth (5000 levels).
+ */
+async function fetchBinanceOrderbook(
+  instrument: string,
+  timestamp: number
+): Promise<AmberdataOrderbookResponse> {
+  let searchParams = [
+    ["exchange", BINANCE_EXCHANGE_ID],
+    ["timeFormat", "milliseconds"],
+
+    // For the search range, we set [timestamp - 1min, timestamp + 1).
+    // This is to ensure that we get the most recent snapshot inclusive of the timestamp
+    // in the response
+    ["startDate", (timestamp - 60000).toString()],
+    ["endDate", (timestamp + 1).toString()],
+  ] as [string, string][]
+
+  const req = await amberdataRequest(
+    `${AMBERDATA_ORDERBOOK_SNAPSHOTS_ROUTE}/${instrument}`,
+    searchParams
+  )
+
+  const res = await fetch(req)
+  return res.json()
+}
+
+/**
+ * Constructs an Amberdata API GET request for the given route & search parameters,
+ * setting the API key header appropriately
+ */
+async function amberdataRequest(
+  route: string,
+  searchParams: [string, string][]
+): Promise<Request> {
+  const amberdataUrl = new URL(`${AMBERDATA_BASE_URL}/${route}`)
+  for (const [key, value] of searchParams) {
+    amberdataUrl.searchParams.set(key, value)
+  }
+  let amberdataReq = new Request(amberdataUrl)
+  amberdataReq.headers.set(
+    API_KEY_HEADER,
+    process.env.AMBERDATA_API_KEY as string
+  )
+
+  return amberdataReq
+}
+
+/** Converts the Binance orderbook data to the expected format */
+function convertOrderbook(
+  binanceOrderbook: AmberdataOrderbookResponse
+): OrderbookResponseData {
+  let data = binanceOrderbook.payload.data
+  let lastIdx = data.length - 1
+  const bids = data[lastIdx].bid.map(parsePriceLevel)
+  const asks = data[lastIdx].ask.map(parsePriceLevel)
+  const timestamp = data[lastIdx].timestamp
+  return { bids, asks, timestamp }
+}
+
+/** Parses a price level from the Binance orderbook into our `PriceLevel` type */
+function parsePriceLevel(amberdataPriceLevel: AmberdataPriceLevel): PriceLevel {
+  return {
+    price: amberdataPriceLevel.price,
+    quantity: amberdataPriceLevel.volume,
+  }
+}


### PR DESCRIPTION
This PR introduces the `/api/get-binance-orderbook` route, which uses the Amberdata API to construct the Binance orderbook for the given pair at the given timestamp. By providing the timestamp as a request parameter, this can be used both for ~realtime and historic orderbook construction.

It does this by pulling the most recent snapshot (relative to the timestamp), then pulling all of the orderbook updates between the snapshot and the timestamp, and applying them into the book.

This has been tested ad-hoc both locally & on the trade preview, I have confirmed that the final timestamp returned is sufficiently close to the requested one (i.e. <=100 ms), the bids/asks are sorted appropriately, and the book seems to match reality. More testing will come as this is integrated into the frontend.