### PR TITLE
trade: predicted savings hook

### DIFF
--- a/trade.renegade.fi/app/api/get-binance-orderbook/route.ts
+++ b/trade.renegade.fi/app/api/get-binance-orderbook/route.ts
@@ -91,7 +91,7 @@ type OrderbookMap = {
 }
 
 /** The reponse data from this route */
-type OrderbookResponseData = {
+export type OrderbookResponseData = {
   timestamp: number
   bids: PriceLevel[]
   asks: PriceLevel[]

--- a/trade.renegade.fi/components/modals/order-confirmation-modal.tsx
+++ b/trade.renegade.fi/components/modals/order-confirmation-modal.tsx
@@ -5,6 +5,7 @@ import {
   MIDPOINT_TOOLTIP,
   ORDER_CONFIRMATION_PROTOCOL_FEE_TOOLTIP,
   ORDER_CONFIRMATION_RELAYER_FEE_TOOLTIP,
+  SAVINGS_TOOLTIP,
 } from "@/lib/tooltip-labels"
 import { Direction } from "@/lib/types"
 import { formatNumber } from "@/lib/utils"
@@ -41,6 +42,7 @@ import { useLocalStorage } from "usehooks-ts"
 import { v4 as uuidv4 } from "uuid"
 import { parseUnits } from "viem/utils"
 
+import { usePredictedSavings } from "@/hooks/use-savings"
 import { useUSDPrice } from "@/hooks/use-usd-price"
 
 import { Tooltip } from "@/components/tooltip"
@@ -86,6 +88,20 @@ export function OrderConfirmationModal({
   )
 
   const balances = useBalances()
+  const predictedSavings = usePredictedSavings(
+    {
+      base: baseToken.address,
+      quote: quoteToken.address,
+      amount: parseAmount(amount, baseToken),
+      side: direction,
+    },
+    0.001,
+    usd
+  )
+  const formattedSavings = useMemo(
+    () => numeral(predictedSavings).format("$0[.]00"),
+    [predictedSavings]
+  )
 
   const hasInsufficientBalance = useMemo(() => {
     if (!amount) return false
@@ -239,6 +255,15 @@ export function OrderConfirmationModal({
                   </Tooltip>
                 </Flex>
                 <Text>$0.00</Text>
+              </Flex>
+              <Flex alignItems="center" justifyContent="space-between">
+                <Flex alignItems="center" gap="1" color="text.secondary">
+                  <Text>Savings vs. Binance</Text>
+                  <Tooltip placement="top" label={SAVINGS_TOOLTIP}>
+                    <Info height={16} width={16} />
+                  </Tooltip>
+                </Flex>
+                <Text>{formattedSavings}</Text>
               </Flex>
             </Flex>
             {hasInsufficientBalance && (

--- a/trade.renegade.fi/hooks/use-savings.ts
+++ b/trade.renegade.fi/hooks/use-savings.ts
@@ -1,0 +1,93 @@
+import { Orderbook } from "@/lib/price-simulation"
+import { Direction } from "@/lib/types"
+import { getBinanceOrderbook } from "@/lib/utils"
+import { Token, formatAmount } from "@renegade-fi/react"
+import { CreateOrderParameters } from "@renegade-fi/react/actions"
+import { useCallback, useEffect, useState } from "react"
+
+export function usePredictedSavings(
+  order: CreateOrderParameters,
+  renegadeFeeRate: number,
+  updateDep: any
+) {
+  const [predictedSavings, setPredictedSavings] = useState(0)
+
+  const fetchPredictedSavings = useCallback(
+    async (
+      baseAddr: `0x${string}`,
+      quoteAddr: `0x${string}`,
+      direction: Direction,
+      amount: bigint
+    ) => {
+      // Fetch the Binance orderbook at the given timestamp
+      const baseToken = Token.findByAddress(baseAddr)
+      const quoteToken = Token.findByAddress(quoteAddr)
+      const timestamp = Date.now()
+      const orderbookRes = await getBinanceOrderbook(
+        baseToken.ticker,
+        quoteToken.ticker,
+        timestamp
+      )
+
+      const orderbook = new Orderbook(orderbookRes.bids, orderbookRes.asks)
+      const quantityFloat = parseFloat(formatAmount(amount, baseToken, 10))
+
+      // Simulate the effective amounts of base / quote that would be transacted on the Binance orderbook
+      const {
+        effectiveBaseAmount: effectiveBinanceBase,
+        effectiveQuoteAmount: effectiveBinanceQuote,
+      } = orderbook.simulateTradeAmounts(quantityFloat, direction)
+
+      // Simulate the effective amounts of base / quote that would be transacted in Renegade (at the midpoint price)
+      const midpointPrice = orderbook.midpointPrice()
+      const renegadeQuote = quantityFloat * midpointPrice
+
+      const effectiveRenegadeBase =
+        direction === Direction.BUY
+          ? quantityFloat * (1 - renegadeFeeRate)
+          : quantityFloat
+
+      const effectiveRenegadeQuote =
+        direction === Direction.SELL
+          ? renegadeQuote * (1 - renegadeFeeRate)
+          : renegadeQuote
+
+      // Calculate the savings in base/quote amounts transacted between the Binance and Renegade trades.
+      // When buying, we save when we receive more base and send less quote than on Binance.
+      // When selling, we save when we receive more quote and send less base than on Binance.
+      const baseSavings =
+        direction === Direction.BUY
+          ? effectiveRenegadeBase - effectiveBinanceBase
+          : effectiveBinanceBase - effectiveRenegadeBase
+
+      const quoteSavings =
+        direction === Direction.SELL
+          ? effectiveRenegadeQuote - effectiveBinanceQuote
+          : effectiveBinanceQuote - effectiveRenegadeQuote
+
+      // Represent the total savings via Renegade, denominated in the quote asset, priced at the current midpoint
+      const totalSavingsAsQuote = baseSavings * midpointPrice + quoteSavings
+
+      setPredictedSavings(totalSavingsAsQuote)
+    },
+    [renegadeFeeRate]
+  )
+
+  useEffect(() => {
+    fetchPredictedSavings(
+      order.base,
+      order.quote,
+      order.side as Direction,
+      order.amount
+    )
+  }, [
+    fetchPredictedSavings,
+    order.amount,
+    order.base,
+    order.quote,
+    order.side,
+    updateDep,
+  ])
+
+  return predictedSavings
+}

--- a/trade.renegade.fi/lib/tooltip-labels.tsx
+++ b/trade.renegade.fi/lib/tooltip-labels.tsx
@@ -87,3 +87,5 @@ export const MAX_BALANCES_TOOLTIP = `Renegade wallets can hold a maximum of ${MA
 export const MAX_ORDERS_TOOLTIP = `Renegade wallets can hold a maximum of ${MAX_ORDERS} orders at a time.`
 export const MAX_BALANCES_PLACE_ORDER_TOOLTIP = `This order would result in more than ${MAX_BALANCES} balances.`
 export const UNUSED_BALANCE_NEEDED_TOOLTIP = `You have an open order that needs an empty balance slot to be filled.`
+export const SAVINGS_TOOLTIP =
+  "What you save in price impact, spread, and fees. Assumes a 0.1% Binance taker fee."

--- a/trade.renegade.fi/lib/utils.ts
+++ b/trade.renegade.fi/lib/utils.ts
@@ -4,6 +4,8 @@ import { Metadata } from "next"
 import numeral from "numeral"
 import { formatUnits } from "viem/utils"
 
+import { OrderbookResponseData } from "@/app/api/get-binance-orderbook/route"
+
 export function safeLocalStorageGetItem(key: string): string | null {
   if (typeof window !== "undefined") {
     return localStorage.getItem(key)
@@ -239,4 +241,19 @@ export function calculateMaxQuote(maxQuote: number, usdPrice: number) {
     return
   }
   return baseMax
+}
+
+export async function getBinanceOrderbook(
+  base_ticker: string,
+  quote_ticker: string,
+  timestamp: number
+): Promise<OrderbookResponseData> {
+  const url = new URL("/api/get-binance-orderbook", window.location.origin)
+  url.searchParams.set("base_ticker", base_ticker)
+  url.searchParams.set("quote_ticker", quote_ticker)
+  url.searchParams.set("timestamp", timestamp.toString())
+  const req = new Request(url)
+  req.headers.set("Content-Type", "application/json")
+  const res = await fetch(req)
+  return res.json()
 }


### PR DESCRIPTION
This PR creates a hook for calculating the predicted savings of executing a trade on Renegade relative to the most recent Binance orderbook. It uses the midpoint price from the fetched orderbook to obviate any jitter / price drift between the fetched book midpoint and the streamed midpoint for a more accurate price.

The hook is used in the order confirmation modal, and is configured to update only when the usd price in the modal updates.