### PR TITLE
trade: refactor useBalances useOrders useFees to return Map

### DIFF
--- a/trade.renegade.fi/app/(desktop)/place-order-button.tsx
+++ b/trade.renegade.fi/app/(desktop)/place-order-button.tsx
@@ -59,10 +59,8 @@ export function PlaceOrderButton({
 
   const hasZeroBalance = useMemo(() => {
     if (!baseTokenAmount) return false
-    const baseBalance =
-      balances.find(({ mint }) => mint === baseAddress)?.amount || BigInt(0)
-    const quoteBalance =
-      balances.find(({ mint }) => mint === quoteAddress)?.amount || BigInt(0)
+    const baseBalance = balances.get(baseAddress)?.amount || BigInt(0)
+    const quoteBalance = balances.get(quoteAddress)?.amount || BigInt(0)
     if (direction === Direction.SELL) {
       return baseBalance === BigInt(0)
     }
@@ -74,9 +72,8 @@ export function PlaceOrderButton({
 
   const isMaxOrders = orders.length === MAX_ORDERS
   const isMaxBalances = backOfQueueBalances.length === MAX_BALANCES
-  const isExistingBalance = balances.find(
-    ({ mint }) =>
-      mint === (direction === Direction.BUY ? baseAddress : quoteAddress)
+  const isExistingBalance = balances.get(
+    direction === Direction.BUY ? baseAddress : quoteAddress
   )
 
   const isDisabled =

--- a/trade.renegade.fi/app/(desktop)/withdraw-button.tsx
+++ b/trade.renegade.fi/app/(desktop)/withdraw-button.tsx
@@ -41,9 +41,7 @@ export default function WithdrawButton({
   const balances = useBalances()
 
   const hasInsufficientBalance = useMemo(() => {
-    const renegadeBalance = balances.find(
-      (b) => b.mint === Token.findByTicker(baseTicker).address
-    )
+    const renegadeBalance = balances.get(Token.findByTicker(baseTicker).address)
     if (!renegadeBalance) return true
     return (
       renegadeBalance.amount <
@@ -74,7 +72,7 @@ export default function WithdrawButton({
       toast.message(QUEUED_WITHDRAWAL_MSG(token, amount))
     }
 
-    if (fees.length > 0) {
+    if (fees.size > 0) {
       await payFees(config)
     }
 

--- a/trade.renegade.fi/components/modals/order-confirmation-modal.tsx
+++ b/trade.renegade.fi/components/modals/order-confirmation-modal.tsx
@@ -89,12 +89,8 @@ export function OrderConfirmationModal({
 
   const hasInsufficientBalance = useMemo(() => {
     if (!amount) return false
-    const baseBalance =
-      balances.find(({ mint }) => mint === baseToken.address)?.amount ||
-      BigInt(0)
-    const quoteBalance =
-      balances.find(({ mint }) => mint === quoteToken.address)?.amount ||
-      BigInt(0)
+    const baseBalance = balances.get(baseToken.address)?.amount || BigInt(0)
+    const quoteBalance = balances.get(quoteToken.address)?.amount || BigInt(0)
     if (direction === Direction.SELL) {
       return baseBalance < parseAmount(amount, baseToken)
     }

--- a/trade.renegade.fi/components/modals/renegade-token-select-modal.tsx
+++ b/trade.renegade.fi/components/modals/renegade-token-select-modal.tsx
@@ -38,9 +38,7 @@ export function TradingTokenSelectModal({
       })
       .map(({ address }) => ({
         address: address as `0x${string}`,
-        balance:
-          balances.find((balance) => balance.mint === address)?.amount ??
-          BigInt(0),
+        balance: balances.get(address)?.amount ?? BigInt(0),
       }))
       .sort((a, b) => Number(b.balance - a.balance)) // Sort in descending order
       .map(({ address, balance }) => ({

--- a/trade.renegade.fi/components/panels/orders-panel.tsx
+++ b/trade.renegade.fi/components/panels/orders-panel.tsx
@@ -242,10 +242,10 @@ function OrdersPanel() {
       >
         {orderHistory.map((order) => {
           const sendBalance =
-            balances.find(({ mint }) =>
+            balances.get(
               order.data.side === "Buy"
-                ? mint === order.data.quote_mint
-                : mint === order.data.base_mint
+                ? order.data.quote_mint
+                : order.data.base_mint
             )?.amount || BigInt(0)
           return (
             <SingleOrder

--- a/trade.renegade.fi/components/panels/wallets-panel.tsx
+++ b/trade.renegade.fi/components/panels/wallets-panel.tsx
@@ -203,9 +203,9 @@ function RenegadeWalletPanel() {
     const wethAddress = Token.findByTicker("WETH").address
     const usdcAddress = Token.findByTicker("USDC").address
 
-    const nonzero: Array<[`0x${string}`, bigint]> = Object.entries(
-      balances
-    ).map(([_, b]) => [b.mint, b.amount])
+    const nonzero: Array<[`0x${string}`, bigint]> = Array.from(
+      balances.values()
+    ).map((b) => [b.mint, b.amount])
     const placeholders: Array<[`0x${string}`, bigint]> = DISPLAY_TOKENS()
       .filter((t) => !nonzero.some(([a]) => a === t.address))
       .map((t) => [t.address as `0x${string}`, BigInt(0)])
@@ -224,7 +224,7 @@ function RenegadeWalletPanel() {
   }, [balances])
 
   const Content = useMemo(() => {
-    if (isConnected && balances.length) {
+    if (isConnected && balances.size) {
       return (
         <>
           <SimpleBar
@@ -292,7 +292,7 @@ function RenegadeWalletPanel() {
     }
   }, [
     address,
-    balances.length,
+    balances.size,
     formattedBalances,
     isConnected,
     isSigningIn,
@@ -325,7 +325,7 @@ function HistorySection() {
   )
   const balances = useBalances()
   if (status !== "in relayer") return null
-  if (!taskHistory.length && !balances.length) return null
+  if (!taskHistory.length && !balances.size) return null
   return (
     <>
       <Tooltip placement="right" label={TASK_HISTORY_TOOLTIP}>

--- a/trade.renegade.fi/hooks/use-max.ts
+++ b/trade.renegade.fi/hooks/use-max.ts
@@ -3,8 +3,6 @@ import { formatUnits } from "viem/utils"
 
 export function useMax(base: string) {
   const balances = useBalances()
-  const max = balances.find(
-    (b) => b.mint === Token.findByTicker(base).address
-  )?.amount
+  const max = balances.get(Token.findByTicker(base).address)?.amount
   return max ? formatUnits(max, Token.findByTicker(base).decimals) : ""
 }

--- a/trade.renegade.fi/package.json
+++ b/trade.renegade.fi/package.json
@@ -22,7 +22,7 @@
     "@datadog/browser-rum": "^5.15.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@renegade-fi/react": "^0.0.45",
+    "@renegade-fi/react": "^0.0.47",
     "@t3-oss/env-nextjs": "^0.6.0",
     "@tanstack/react-query": "^5.24.1",
     "@vercel/analytics": "^1.2.2",

--- a/trade.renegade.fi/pnpm-lock.yaml
+++ b/trade.renegade.fi/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^11.11.0
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.2.77)(react@18.2.0))(@types/react@18.2.77)(react@18.2.0)
       '@renegade-fi/react':
-        specifier: ^0.0.45
-        version: 0.0.45(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))
+        specifier: ^0.0.47
+        version: 0.0.47(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))
       '@t3-oss/env-nextjs':
         specifier: ^0.6.0
         version: 0.6.1(typescript@5.1.6)(zod@3.22.4)
@@ -2090,8 +2090,8 @@ packages:
       '@tanstack/query-core':
         optional: true
 
-  '@renegade-fi/react@0.0.45':
-    resolution: {integrity: sha512-EiNIKh960Jg1QaONQDjfAJS7Y/TLzFBesl+2lLnM+9Im+OIlA9Lokk9nmmZxL3UyEbl05+9pudbcWhPZTqNn4g==}
+  '@renegade-fi/react@0.0.47':
+    resolution: {integrity: sha512-0WoLbsA0/HpTSUHAWFGFQoL3QLsAGFsoZp+eTvVb3IInKTqWHvZu7Hzqfu10NqYNOYULodmftp24QybjuEU51Q==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -8713,7 +8713,7 @@ snapshots:
       - react
       - ws
 
-  '@renegade-fi/react@0.0.45(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))':
+  '@renegade-fi/react@0.0.47(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))':
     dependencies:
       '@renegade-fi/core': 0.0.44(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))
       '@tanstack/react-query': 5.29.2(react@18.2.0)


### PR DESCRIPTION
This PR bumps sdk version and uses the updated `Map` type that `useBalances`, `useOrders`, and `useFees` now return.