### PR TITLE
trade: prevent create wallet when rpc getLogs req fails

### DIFF
--- a/trade.renegade.fi/app/api/get-logs/route.ts
+++ b/trade.renegade.fi/app/api/get-logs/route.ts
@@ -1,0 +1,36 @@
+import { chain } from "@/lib/viem"
+import { NextRequest } from "next/server"
+import { createPublicClient, http, parseAbiItem } from "viem"
+
+export const runtime = "edge"
+
+// Necessary because public RPC does not support getting logs
+const viemClient = createPublicClient({
+  chain,
+  transport: http(process.env.RPC_URL),
+})
+
+export async function GET(req: NextRequest) {
+  try {
+    const blinderShare = BigInt(
+      req.nextUrl.searchParams.get("blinderShare") || "0"
+    )
+    if (!blinderShare) {
+      throw new Error("Blinder share is required")
+    }
+    const logs = await viemClient.getLogs({
+      address: process.env.NEXT_PUBLIC_DARKPOOL_CONTRACT,
+      event: parseAbiItem(
+        "event WalletUpdated(uint256 indexed wallet_blinder_share)"
+      ),
+      args: {
+        wallet_blinder_share: blinderShare,
+      },
+      fromBlock: BigInt(process.env.FROM_BLOCK || 0),
+    })
+    return new Response(JSON.stringify({ logs: logs.length }))
+  } catch (error) {
+    console.error(error)
+    return new Response(JSON.stringify({ error }), { status: 500 })
+  }
+}

--- a/trade.renegade.fi/app/providers.tsx
+++ b/trade.renegade.fi/app/providers.tsx
@@ -21,8 +21,11 @@ import {
   createConfig as createSDKConfig,
   useStatus,
 } from "@renegade-fi/react"
-import { focusManager } from "@tanstack/react-query"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  QueryClient,
+  QueryClientProvider,
+  focusManager,
+} from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { ConnectKitProvider, getDefaultConfig } from "connectkit"
 import dayjs from "dayjs"

--- a/trade.renegade.fi/package.json
+++ b/trade.renegade.fi/package.json
@@ -22,7 +22,7 @@
     "@datadog/browser-rum": "^5.15.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@renegade-fi/react": "^0.0.47",
+    "@renegade-fi/react": "^0.0.49",
     "@t3-oss/env-nextjs": "^0.6.0",
     "@tanstack/react-query": "^5.24.1",
     "@vercel/analytics": "^1.2.2",

--- a/trade.renegade.fi/pnpm-lock.yaml
+++ b/trade.renegade.fi/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^11.11.0
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.2.77)(react@18.2.0))(@types/react@18.2.77)(react@18.2.0)
       '@renegade-fi/react':
-        specifier: ^0.0.47
-        version: 0.0.47(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))
+        specifier: ^0.0.49
+        version: 0.0.49(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))
       '@t3-oss/env-nextjs':
         specifier: ^0.6.0
         version: 0.6.1(typescript@5.1.6)(zod@3.22.4)
@@ -2081,8 +2081,8 @@ packages:
     peerDependencies:
       react-native: '*'
 
-  '@renegade-fi/core@0.0.44':
-    resolution: {integrity: sha512-dJJrrHDUVrlHOIXZm43WHpChxW63S4pEZDCeuz6SNurlixE0y3Y+NI6wR3sAnJoCifaYibYza20zSNM6NQzv3g==}
+  '@renegade-fi/core@0.0.46':
+    resolution: {integrity: sha512-FKmTk5tqSJmzQ94wyCj7lJ8aynXR/673c1Ua3ALFu/+1wlNTNmubTdXwQcZZn2iJFsWCYeihsvtwhS/5HXs9CQ==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       viem: 2.x
@@ -2090,8 +2090,8 @@ packages:
       '@tanstack/query-core':
         optional: true
 
-  '@renegade-fi/react@0.0.47':
-    resolution: {integrity: sha512-0WoLbsA0/HpTSUHAWFGFQoL3QLsAGFsoZp+eTvVb3IInKTqWHvZu7Hzqfu10NqYNOYULodmftp24QybjuEU51Q==}
+  '@renegade-fi/react@0.0.49':
+    resolution: {integrity: sha512-+Dd7YTEyadtYFR9lxOK5aCH/eHXil52bZ7dTZ7kWlU/OqlLCS6KV0EK/ltjl4ZfsB8XIsdEYGEqNaMJRBfCYyA==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -8696,7 +8696,7 @@ snapshots:
       nullthrows: 1.1.1
       react-native: 0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(react@18.2.0)
 
-  '@renegade-fi/core@0.0.44(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))':
+  '@renegade-fi/core@0.0.46(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))':
     dependencies:
       axios: 1.7.2
       isomorphic-ws: 5.0.0(ws@8.13.0(bufferutil@4.0.8))
@@ -8713,9 +8713,9 @@ snapshots:
       - react
       - ws
 
-  '@renegade-fi/react@0.0.47(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))':
+  '@renegade-fi/react@0.0.49(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.77)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))':
     dependencies:
-      '@renegade-fi/core': 0.0.44(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))
+      '@renegade-fi/core': 0.0.46(@tanstack/query-core@5.29.0)(@types/react@18.2.77)(react@18.2.0)(viem@2.9.28(bufferutil@4.0.8)(typescript@5.1.6)(zod@3.22.4))(ws@8.13.0(bufferutil@4.0.8))
       '@tanstack/react-query': 5.29.2(react@18.2.0)
       json-bigint: 1.0.0
       react: 18.2.0


### PR DESCRIPTION
This PR bumps the SDK to a version that prevents create wallet tasks from being executed when the get logs RPC request fails. Only when the request returns 0 logs does the create wallet task get started.